### PR TITLE
Ft/model: Add domain models, DTOs & enums

### DIFF
--- a/doc/design/README.md
+++ b/doc/design/README.md
@@ -11,13 +11,65 @@ Design documents define:
 These documents are normative. If there is a conflict between
 implementation and a design requirement, the design requirement wins.
 
+## Architecture overview
+
+The system is a content-addressed paste/image service. Every upload is
+immutable and identified by a hash-derived short code.
+
+### Layers
+
+Dependencies flow inward. Lower layers must not depend on higher layers.
+
+```
+web/ → service/ → repo/ → storage/ → model/ → util/
+```
+
+- **web/** — HTTP boundary (FastAPI)
+- **service/** — orchestration and ingest logic
+- **repo/** — persistence, collision resolution
+- **storage/** — bytes in, bytes out
+- **model/** — domain types, DTOs, enums (no I/O)
+- **util/** — hashing, helpers
+
+### Ingest flow
+
+```
+POST /upload
+     │
+     ▼
+   web/ (receives bytes, auth)
+     │
+     ▼
+   IngestService.build_plan()
+     │  - hashes content (util/)
+     │  - infers kind/format
+     │  - returns WritePlan
+     ▼
+   WritePlan (frozen DTO)
+     │
+     ▼
+   Repository.persist()
+     │  - resolves collisions
+     │  - writes metadata to DB
+     ▼
+   StorageBackend.put()
+        - writes bytes to filesystem
+```
+
+WritePlan is the hard interface between inference and persistence.
+Neither IngestService nor Repository depend on each other.
+
 ## Documents
 
-- [Design Requirements - MVP (v0.0.1)](./mvp.md)
+- [Design Requirements — MVP (v0.0.1)](./mvp.md)
   - Authoritative scope and invariants for the initial implementation
   - All MVP work must conform to this document
 
-- [Design Requirements - v1.0](./v1.md)
+- [Architecture Decisions](./architecture.md)
+  - Records key decisions and rationale
+  - Updated as design evolves
+
+- [Design Requirements — v1.0](./v1.md)
   - Post-MVP direction and constraints
   - Explains why certain MVP decisions exist
   - Not to be implemented until the MVP is complete

--- a/doc/design/mvp.md
+++ b/doc/design/mvp.md
@@ -136,7 +136,6 @@ Storage model:
 - `kind` : `ItemKind(Enum)`
 - `mime`: str
 - `size_b`: int
-- `store_key` (str, filesystem path or object key later)
 - `created_at` (int, Unix Epoch UTC)
 - `uid` (int, FK -> `User`)
 - `perm` (`private`, `unlisted`, `public`, refactoring with `gid`)
@@ -321,6 +320,16 @@ class StorageBackend(Protocol):
         ...
 ```
 
+#### Storage path derivation
+
+Paths are derived, not stored.
+Given an item's `code` and `mime`, the storage backend computes:
+
+```
+{STORAGE_ROOT}/{code}.{ext}
+```
+
+Extension is derived from MIME type. This keeps Item lean and avoids redundancy
 ---
 
 ## 6. HTTP & UI (MVP)

--- a/doc/design/mvp.md
+++ b/doc/design/mvp.md
@@ -136,10 +136,11 @@ Storage model:
 - `kind` : `ItemKind(Enum)`
 - `mime`: str
 - `size_b`: int
-- `created_at` (int, Unix Epoch UTC)
 - `uid` (int, FK -> `User`)
 - `perm` (`private`, `unlisted`, `public`, refactoring with `gid`)
   - Very simple for now till `Group` model exists
+- `upload_at` (int, Unix Epoch UTC)
+- `origin_at` (int | None, original file creation time if known)
 
 ### 4.2 TextItem (heavy-load-bearing)
 

--- a/doc/design/mvp.md
+++ b/doc/design/mvp.md
@@ -131,16 +131,20 @@ Storage model:
 #### Item Fields (conceptual)
 
 - `code` (PK)
-- `hash_remainder`
-- `kind` (`text`, `image`, `link`)
-- `mime_type`
-- `size_bytes`
-- `storage_key` (filesystem path or object key later)
-- `created_at`
-- `owner_user_id`
-- `visibility` (`private`, `unlisted`, `public`)
+- `hash_rest`
+  - Note: `code` + `hash_rest` = full hash, each code with its len is unique
+- `kind` : `ItemKind(Enum)`
+- `mime`: str
+- `size_b`: int
+- `store_key` (str, filesystem path or object key later)
+- `created_at` (int, Unix Epoch UTC)
+- `uid` (int, FK -> `User`)
+- `perm` (`private`, `unlisted`, `public`, refactoring with `gid`)
+  - Very simple for now till `Group` model exists
 
 ### 4.2 TextItem (heavy-load-bearing)
+
+### 4.2 TextItem
 
 #### TextItem Philosophy
 
@@ -149,14 +153,10 @@ Storage model:
 
 #### TextItem Fields
 
-- `code` (FK → Item)
-- `format` (single authoritative field)
-  - Examples: `plain`, `markdown`, `python`, `bash`, `json`, `yaml`, `csv`, `html`
-- `title` (optional)
-- optional derived metadata:
-  - `line_count`
-  - `char_count`
-  - `preview` (optional small snippet for fast `/info`)
+- `code` (PK, FK → Item)
+- `format`
+  - str
+  - *(`plain`, `markdown`, `python`, `bash`, `json`, `yaml`, `csv`, `html`)*
 
 #### TextItem Rules
 
@@ -168,13 +168,16 @@ Storage model:
 
 #### PicItem Fields
 
-- `code` (FK → Item)
-- `format` (`png`, `jpeg`, `gif`, `webp`, `svg`)
-- `width`
-- `height`
-- optional EXIF reference (defer deep EXIF features to v1 if desired)
+- `code` (PK, FK → Item)
+- `format` (str, e.g. `png`, `jpeg`, `gif`, `webp`)
+- `width` (int)
+- `height` (int)
+
+SVG and EXIF support deferred to post-MVP.
 
 ### 4.4 LinkItem (explicit in MVP)
+
+### 4.4 LinkItem
 
 #### LinkItem Rules
 
@@ -183,8 +186,8 @@ Storage model:
 
 #### LinkItem Fields
 
-- `code` (FK → Item)
-- `target_url` (validated; schemes default to http/https)
+- `code` (PK, FK → Item)
+- `url` (str, validated; schemes default to http/https)
 
 ---
 
@@ -206,18 +209,11 @@ Framework-agnostic handoff between inference and persistence.
 #### WritePlan Interface
 
 ```python
-from dataclasses import dataclass
-from pathlib import Path
-from typing import Optional, Dict, Any, Literal
-
-PayloadKind = Literal["bytes", "file"]
-ItemKind = Literal["text", "image", "link"]
-
 @dataclass(frozen=True)
 class WritePlan:
     # Identity
-    full_hash: str                 # 24-char base32 string
-    min_code_length: int
+    hash_full: str                 # 24-char base32 string
+    code_min_len: int
 
     # Payload reference (exactly one)
     payload_kind: PayloadKind
@@ -226,20 +222,19 @@ class WritePlan:
 
     # Classification & metadata
     kind: ItemKind
-    mime_type: str
-    size_bytes: int
+    mime: str
+    size_b: int
 
     # Text-specific
     text_format: Optional[str] = None     # e.g. "markdown", "python", "json"
-    text_meta: Optional[Dict[str, Any]] = None
 
     # Image-specific
-    image_format: Optional[str] = None    # "png", "jpeg", "svg", ...
-    image_meta: Optional[Dict[str, Any]] = None
-    exif: Optional[Dict[str, Any]] = None
+    pic_format: Optional[str] = None      # e.g. "png", "jpeg", "gif", "webp"
+    pic_width: Optional[int] = None
+    pic_height: Optional[int] = None
 
     # Link-specific
-    link_target_url: Optional[str] = None
+    link_url: Optional[str] = None
 ```
 
 ### 5.2 IngestService (hard interface)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dev-dependencies = [
   "black>=24.0",
   "mypy>=1.10",
   "pytest>=8.0",
+  "pytest-xdist",
 ]
 
 [tool.pytest]

--- a/src/depo/model/__init__.py
+++ b/src/depo/model/__init__.py
@@ -1,0 +1,26 @@
+# src/depo/model/__init__.py
+"""
+Domain models, DTOs, and enums.
+
+Pure Python with no I/O dependencies.
+Only meant to structure and contain data.
+
+Author: Marcus Grant
+Date: 2026-01-20
+License: Apache-2.0
+"""
+
+from depo.model.enums import ItemKind, PayloadKind, Visibility
+from depo.model.item import Item, LinkItem, PicItem, TextItem
+from depo.model.write_plan import WritePlan
+
+__all__ = [
+    "ItemKind",
+    "PayloadKind",
+    "Visibility",
+    "Item",
+    "TextItem",
+    "PicItem",
+    "LinkItem",
+    "WritePlan",
+]

--- a/src/depo/model/enums.py
+++ b/src/depo/model/enums.py
@@ -1,0 +1,19 @@
+# src/depo/model/enums.py
+from enum import StrEnum
+
+
+class ItemKind(StrEnum):
+    TEXT = "txt"
+    LINK = "url"
+    PICTURE = "pic"
+
+
+class Visibility(StrEnum):
+    UNLISTED = "unl"
+    PRIVATE = "prv"
+    PUBLIC = "pub"
+
+
+class PayloadKind(StrEnum):
+    BYTES = "byte"
+    FILE = "file"

--- a/src/depo/model/item.py
+++ b/src/depo/model/item.py
@@ -15,6 +15,8 @@ from dataclasses import dataclass
 
 from depo.model.enums import ItemKind, Visibility
 
+# TODO: Create enums for formats and mimes
+
 
 @dataclass(frozen=True)
 class Item:
@@ -25,4 +27,42 @@ class Item:
     size_b: int
     created_at: int
     uid: int
-    perm: Visibility = Visibility.PUBLIC
+    perm: Visibility
+
+
+@dataclass(frozen=True)
+class TextItem(Item):
+    """
+    Text content item.
+
+    Covers plain text, code, markdown, data formats (JSON, YAML, CSV).
+    Format field determines rendering behavior on /info.
+    """
+
+    format: str = "txt"  # plaintext if nothing specified
+
+
+@dataclass(frozen=True)
+class LinkItem(Item):
+    """
+    URL shortener/bookmarking item.
+
+    Explicit creation only; no auto-detection.
+    Redirects to target URL on access.
+    """
+
+    url: str
+
+
+@dataclass(frozen=True)
+class PicItem(Item):
+    """
+    Image content item.
+
+    Raster formats only for MVP (PNG, JPEG, GIF, WEBP).
+    Dimensions required; EXIF support deferred.
+    """
+
+    format: str
+    width: int
+    height: int

--- a/src/depo/model/item.py
+++ b/src/depo/model/item.py
@@ -18,19 +18,20 @@ from depo.model.enums import ItemKind, Visibility
 # TODO: Create enums for formats and mimes
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class Item:
     code: str
     hash_rest: str
     kind: ItemKind
     mime: str
     size_b: int
-    created_at: int
     uid: int
     perm: Visibility
+    upload_at: int
+    origin_at: int | None = None
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class TextItem(Item):
     """
     Text content item.
@@ -42,7 +43,7 @@ class TextItem(Item):
     format: str = "txt"  # plaintext if nothing specified
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class LinkItem(Item):
     """
     URL shortener/bookmarking item.
@@ -54,7 +55,7 @@ class LinkItem(Item):
     url: str
 
 
-@dataclass(frozen=True)
+@dataclass(frozen=True, kw_only=True)
 class PicItem(Item):
     """
     Image content item.

--- a/src/depo/model/item.py
+++ b/src/depo/model/item.py
@@ -1,0 +1,28 @@
+# src/depo/model/item.py
+"""
+Domain models for content items.
+
+Defines Item base class & its subtypes: TextItem, PicItem, LinkItem, etc.
+These are pure, frozen dataclasses representing content-addressed items.
+No I/O or framework dependencies.
+
+Author: Marcus Grant
+Date: 2026-01-19
+License: Apache-2.0
+"""
+
+from dataclasses import dataclass
+
+from depo.model.enums import ItemKind, Visibility
+
+
+@dataclass(frozen=True)
+class Item:
+    code: str
+    hash_rest: str
+    kind: ItemKind
+    mime: str
+    size_b: int
+    created_at: int
+    uid: int
+    perm: Visibility = Visibility.PUBLIC

--- a/src/depo/model/write_plan.py
+++ b/src/depo/model/write_plan.py
@@ -1,0 +1,35 @@
+# src/depo/model/write_plan.py
+"""
+WritePlan DTO for ingest pipeline.
+
+Frozen dataclass representing the handoff between IngestService and Repository.
+Contains all info needed to persist an item without framework dependencies.
+
+Author: Marcus Grant
+Date: 2026-01-20
+License: Apache-2.0
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from depo.model.enums import ItemKind, PayloadKind
+
+
+@dataclass(frozen=True)
+class WritePlan:
+    hash_full: str
+    code_min_len: int
+    payload_kind: PayloadKind
+    kind: ItemKind
+    mime: str
+    size_b: int
+    upload_at: int
+    origin_at: int | None = None
+    payload_bytes: bytes | None = None
+    payload_path: Path | None = None
+    text_format: str | None = None
+    link_url: str | None = None
+    pic_format: str | None = None
+    pic_width: int | None = None
+    pic_height: int | None = None

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -15,9 +15,10 @@ _ITEM_DEFAULTS = dict(
     kind=ItemKind.TEXT,
     mime="text/plain",
     size_b=100,
-    created_at=1234567890,
     uid=1,
     perm=Visibility.PUBLIC,
+    upload_at=1234567890,
+    origin_at=None,
 )
 
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -3,12 +3,15 @@
 # Date: 2026-01-09
 # License: Apache-2.0
 
-from depo.model.enums import ItemKind, Visibility
+from depo.model.enums import ItemKind, PayloadKind, Visibility
 from depo.model.item import Item, LinkItem, PicItem, TextItem
+from depo.model.write_plan import WritePlan
+
+### Item Factories ###
 
 _ITEM_DEFAULTS = dict(
     code="ABC12345",
-    hash_rest="06789DEFGHKMNPQRSTVWXYZ",
+    hash_rest="06789DEFGHKMNPQR",
     kind=ItemKind.TEXT,
     mime="text/plain",
     size_b=100,
@@ -45,6 +48,8 @@ def make_pic_item(**overrides) -> PicItem:
         height=240,
     )
     return PicItem(**(defaults | overrides))  # pyright: ignore[reportArgumentType]
+
+
 ### WritePlan Factories ###
 
 _WRITE_PLAN_DEFAULTS = dict(

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -45,3 +45,26 @@ def make_pic_item(**overrides) -> PicItem:
         height=240,
     )
     return PicItem(**(defaults | overrides))  # pyright: ignore[reportArgumentType]
+### WritePlan Factories ###
+
+_WRITE_PLAN_DEFAULTS = dict(
+    hash_full="ABC1234567890DEFGHKMNPQR",
+    code_min_len=8,
+    payload_kind=PayloadKind.BYTES,
+    kind=ItemKind.TEXT,
+    mime="text/plain",
+    size_b=100,
+    upload_at=1234567890,
+    origin_at=None,
+    payload_bytes=None,
+    payload_path=None,
+    text_format=None,
+    link_url=None,
+    pic_format=None,
+    pic_width=None,
+    pic_height=None,
+)
+
+
+def make_write_plan(**overrides) -> WritePlan:
+    return WritePlan(**(_WRITE_PLAN_DEFAULTS | overrides))  # pyright: ignore[reportArgumentType]

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,47 @@
+# tests/factories.py
+# Author: Marcus Grant
+# Date: 2026-01-09
+# License: Apache-2.0
+
+from depo.model.enums import ItemKind, Visibility
+from depo.model.item import Item, LinkItem, PicItem, TextItem
+
+_ITEM_DEFAULTS = dict(
+    code="ABC12345",
+    hash_rest="06789DEFGHKMNPQRSTVWXYZ",
+    kind=ItemKind.TEXT,
+    mime="text/plain",
+    size_b=100,
+    created_at=1234567890,
+    uid=1,
+    perm=Visibility.PUBLIC,
+)
+
+
+def make_item(**overrides) -> Item:
+    return Item(**(_ITEM_DEFAULTS | overrides))  # pyright: ignore[reportArgumentType]
+
+
+def make_text_item(**overrides) -> TextItem:
+    defaults = _ITEM_DEFAULTS | dict(format="txt")
+    return TextItem(**(defaults | overrides))  # pyright: ignore[reportArgumentType]
+
+
+def make_link_item(**overrides) -> LinkItem:
+    defaults = _ITEM_DEFAULTS | dict(
+        kind=ItemKind.LINK,
+        mime="text/uri-list",
+        url="https://example.com",
+    )
+    return LinkItem(**(defaults | overrides))  # pyright: ignore[reportArgumentType]
+
+
+def make_pic_item(**overrides) -> PicItem:
+    defaults = _ITEM_DEFAULTS | dict(
+        kind=ItemKind.PICTURE,
+        mime="image/png",
+        format="png",
+        width=320,
+        height=240,
+    )
+    return PicItem(**(defaults | overrides))  # pyright: ignore[reportArgumentType]

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,45 @@
+# tests/helpers.py
+"""
+Helper functions for common testing procedures/patterns
+
+Author: Marcus Grant
+Date: 2026-01-20
+License: Apache-2.0
+"""
+
+from dataclasses import MISSING, fields
+from typing import Any
+
+
+def assert_field(cls: type, name: str, typ: type, required: bool, default: Any) -> None:
+    """
+    Assert a dataclass field has the expected specification.
+
+    Args:
+        cls: The dataclass class to inspect.
+        name: Expected field name.
+        typ: Expected field type annotation.
+        required: If True, field must have no default value.
+        default: Expected default value (ignored if required is True).
+
+    Raises:
+        AssertionError: If any expectation is not met.
+
+    Example:
+        @pytest.mark.parametrize(("name", "typ", "required", "default"), [
+            ("code", str, True, None),
+            ("size_b", int, True, None),
+            ("perm", Visibility, False, Visibility.PUBLIC),
+        ])
+        def test_fields(self, name, typ, required, default):
+            assert_field(Item, name, typ, required, default)
+    """
+    field_map = {f.name: f for f in fields(cls)}
+    assert name in field_map, f"missing field: {name}"
+    f = field_map[name]
+    assert f.type == typ, f"{name} type mismatch: expected {typ}, got {f.type}"
+    if required:
+        assert f.default is MISSING, f"{name} should be required"
+    else:
+        msg = f"{name} default mismatch: expected {default}, got {f.default}"
+        assert f.default == default, msg

--- a/tests/model/test_enums.py
+++ b/tests/model/test_enums.py
@@ -1,8 +1,9 @@
 # Tests for depo/model/enums.py
 from enum import StrEnum
+
 import pytest
 
-from depo.model.enums import ItemKind, Visibility, PayloadKind
+from depo.model.enums import ItemKind, PayloadKind, Visibility
 
 
 class TestItemKind:

--- a/tests/model/test_enums.py
+++ b/tests/model/test_enums.py
@@ -1,0 +1,78 @@
+# Tests for depo/model/enums.py
+from enum import StrEnum
+import pytest
+
+from depo.model.enums import ItemKind, Visibility, PayloadKind
+
+
+class TestItemKind:
+    """Tests the ItemKind enum used as a content discriminator."""
+
+    def test_is_str_enum(self):
+        """Always a StrEnum subclass."""
+        for member in ItemKind:
+            assert isinstance(member, StrEnum)
+
+    def test_member_count(self):
+        """Always 3 members for now"""
+        assert len(ItemKind) == 3
+
+    @pytest.mark.parametrize(
+        "key,val", [("TEXT", "txt"), ("LINK", "url"), ("PICTURE", "pic")]
+    )
+    def test_member_key_values(self, key, val):
+        """Should have these expected member names"""
+        member = ItemKind[key]
+        assert member.name == key
+        assert member.value == val
+        assert member == val
+
+
+class TestVisibility:
+    """Test visibility or perm or Permission Enum"""
+
+    def test_is_str_enum(self):
+        """Always a StrEnum subclass."""
+        for member in Visibility:
+            assert isinstance(member, StrEnum)
+
+    def test_member_count(self):
+        """Always 3 members for now"""
+        assert len(Visibility) == 3
+
+    @pytest.mark.parametrize(
+        "key,val", [("UNLISTED", "unl"), ("PRIVATE", "prv"), ("PUBLIC", "pub")]
+    )
+    def test_member_key_values(self, key, val):
+        """Should have these expected member names"""
+        member = Visibility[key]
+        assert member.name == key
+        assert member.value == val
+        assert member == val
+
+
+# PayloadKind
+#
+# - Has exactly two members
+# - BYTES member exists with value "bytes"
+# - FILE member exists with value "file"
+# - Members compare equal to their string values
+class TestPayloadKind:
+    """Test PayloadKind enum, gives info on how to handle payload"""
+
+    def test_is_str_enum(self):
+        """Always a StrEnum subclass."""
+        for member in PayloadKind:
+            assert isinstance(member, StrEnum)
+
+    def test_member_count(self):
+        """Always 2 members for now"""
+        assert len(PayloadKind) == 2
+
+    @pytest.mark.parametrize("key,val", [("BYTES", "byte"), ("FILE", "file")])
+    def test_member_key_values(self, key, val):
+        """Should have these expected member names"""
+        member = PayloadKind[key]
+        assert member.name == key
+        assert member.value == val
+        assert member == val

--- a/tests/model/test_item.py
+++ b/tests/model/test_item.py
@@ -21,9 +21,10 @@ _ITEM_PARAMS = [
     ("kind", ItemKind, True, None),
     ("mime", str, True, None),
     ("size_b", int, True, None),
-    ("created_at", int, True, None),
     ("uid", int, True, None),
     ("perm", Visibility, True, None),
+    ("upload_at", int, True, None),
+    ("origin_at", int | None, False, None),
 ]
 
 

--- a/tests/model/test_item.py
+++ b/tests/model/test_item.py
@@ -1,0 +1,84 @@
+# tests/model/test_item.py
+# tests depo.model.item
+# Marcus Grant 2026-01-19
+
+from dataclasses import is_dataclass, FrozenInstanceError, fields, MISSING
+import pytest
+
+from depo.model.item import Item
+from depo.model.enums import ItemKind, Visibility
+
+
+class TestItem:
+    """Tests for the Item model class"""
+
+    def test_instance_dataclass(self):
+        """Is a dataclass"""
+        assert is_dataclass(Item)
+
+    @pytest.mark.parametrize(
+        ("name", "typ", "required", "default"),
+        [
+            ("code", str, True, None),
+            ("hash_rest", str, True, None),
+            ("kind", ItemKind, True, None),
+            ("mime", str, True, None),
+            ("size_b", int, True, None),
+            ("created_at", int, True, None),
+            ("uid", int, True, None),
+            ("perm", Visibility, False, Visibility.PUBLIC),
+        ],
+    )
+    def test_fields(self, name, typ, required, default):
+        """Test name, type, optionality, default value of all fields"""
+        field_map = {f.name: f for f in fields(Item)}
+        f = field_map[name]
+        assert name in field_map, f"missing field: {name}"
+        assert f.type is typ, f"{name} type mismatch"
+        if required:
+            assert f.default is MISSING, f"{name} should be required"
+        else:
+            assert f.default == default, f"{name} default val mismatch"
+
+    def test_frozen(self):
+        """Is frozen (immutable)."""
+        item = Item(
+            code="ABC",
+            hash_rest="DEF",
+            kind=ItemKind.TEXT,
+            mime="text/plain",
+            size_b=100,
+            created_at=1234567890,
+            uid=1,
+        )
+        with pytest.raises(FrozenInstanceError):
+            item.code = "new value"  # pyright: ignore[reportAttributeAccessIssue] noqa
+
+
+# --- TextItem ---
+# 1. Is a dataclass
+# 2. Is frozen
+# 3. Is subclass of Item
+# 4. Has field `format` of type `str`
+# 5. Inherits all Item fields
+# 6. Can instantiate with all required fields
+
+
+# --- PicItem ---
+# 1. Is a dataclass
+# 2. Is frozen
+# 3. Is subclass of Item
+# 4. Has field `format` of type `str`
+# 5. Has field `width` of type `int`
+# 6. Has field `height` of type `int`
+# 7. Inherits all Item fields
+# 8. Can instantiate with all required fields
+
+
+# --- LinkItem ---
+# 1. Is a dataclass
+# 2. Is frozen
+# 3. Is subclass of Item
+# 4. Has field `url` of type `str`
+# 5. Inherits all Item fields
+# 6. Can instantiate with all required fields

--- a/tests/model/test_item.py
+++ b/tests/model/test_item.py
@@ -2,11 +2,40 @@
 # tests depo.model.item
 # Marcus Grant 2026-01-19
 
-from dataclasses import is_dataclass, FrozenInstanceError, fields, MISSING
-import pytest
+from dataclasses import MISSING, FrozenInstanceError, fields, is_dataclass
 
-from depo.model.item import Item
+import pytest
+from tests.factories import make_item, make_link_item, make_pic_item, make_text_item
+
 from depo.model.enums import ItemKind, Visibility
+from depo.model.item import Item, LinkItem, PicItem, TextItem
+
+# Used to verify field specifications
+# "name": field name, "typ": type (avoid py keyword),
+# "required": non-optional, "default": default value
+_ITEM_PARAM_NAMES = ("name", "typ", "required", "default")
+_ITEM_PARAMS = [
+    ("code", str, True, None),
+    ("hash_rest", str, True, None),
+    ("kind", ItemKind, True, None),
+    ("mime", str, True, None),
+    ("size_b", int, True, None),
+    ("created_at", int, True, None),
+    ("uid", int, True, None),
+    ("perm", Visibility, True, None),
+]
+
+
+# TODO: Refactor with this assetion helper:
+def _assert_field(cls, name, typ, required, default):
+    field_map = {f.name: f for f in fields(cls)}
+    assert name in field_map, f"missing field: {name}"
+    f = field_map[name]
+    assert f.type is typ, f"{name} type mismatch"
+    if required:
+        assert f.default is MISSING, f"{name} should be required"
+    else:
+        assert f.default == default, f"{name} default val mismatch"
 
 
 class TestItem:
@@ -16,69 +45,122 @@ class TestItem:
         """Is a dataclass"""
         assert is_dataclass(Item)
 
-    @pytest.mark.parametrize(
-        ("name", "typ", "required", "default"),
-        [
-            ("code", str, True, None),
-            ("hash_rest", str, True, None),
-            ("kind", ItemKind, True, None),
-            ("mime", str, True, None),
-            ("size_b", int, True, None),
-            ("created_at", int, True, None),
-            ("uid", int, True, None),
-            ("perm", Visibility, False, Visibility.PUBLIC),
-        ],
-    )
+    @pytest.mark.parametrize(_ITEM_PARAM_NAMES, _ITEM_PARAMS)
     def test_fields(self, name, typ, required, default):
         """Test name, type, optionality, default value of all fields"""
-        field_map = {f.name: f for f in fields(Item)}
-        f = field_map[name]
-        assert name in field_map, f"missing field: {name}"
-        assert f.type is typ, f"{name} type mismatch"
-        if required:
-            assert f.default is MISSING, f"{name} should be required"
-        else:
-            assert f.default == default, f"{name} default val mismatch"
+        _assert_field(Item, name, typ, required, default)
 
     def test_frozen(self):
         """Is frozen (immutable)."""
-        item = Item(
-            code="ABC",
-            hash_rest="DEF",
-            kind=ItemKind.TEXT,
-            mime="text/plain",
-            size_b=100,
-            created_at=1234567890,
-            uid=1,
-        )
+        item = make_item()
         with pytest.raises(FrozenInstanceError):
             item.code = "new value"  # pyright: ignore[reportAttributeAccessIssue] noqa
 
 
-# --- TextItem ---
-# 1. Is a dataclass
-# 2. Is frozen
-# 3. Is subclass of Item
-# 4. Has field `format` of type `str`
-# 5. Inherits all Item fields
-# 6. Can instantiate with all required fields
+class TestTextItem:
+    """Test TextItem dataclass (subtype of Item for text content)"""
+
+    def test_instance_dataclass(self):
+        """Is a dataclass"""
+        assert is_dataclass(TextItem)
+
+    def test_subclass_of_item(self):
+        """Is a subclass of Item"""
+        assert issubclass(TextItem, Item)
+
+    @pytest.mark.parametrize(_ITEM_PARAM_NAMES, [("format", str, False, "txt")])
+    def test_fields(self, name, typ, required, default):
+        """Test name, type, optionality, default value of all fields"""
+        _assert_field(TextItem, name, typ, required, default)
+
+    @pytest.mark.parametrize(_ITEM_PARAM_NAMES, _ITEM_PARAMS)
+    def test_inherits_item_fields(self, name, typ, required, default):
+        """Inherits all Item field specifications"""
+        _assert_field(TextItem, name, typ, required, default)
+
+    def test_frozen(self):
+        """Is frozen (immutable)"""
+        textitem = make_text_item()
+        with pytest.raises(FrozenInstanceError):
+            textitem.code = "F00BAR"  # pyright: ignore[reportAttributeAccessIssue] noqa
+
+    def test_instantiate(self):
+        """Can instantiate with all requried fields"""
+        textitem = make_text_item()
+        assert textitem.code == "ABC12345"
+        assert textitem.format == "txt"
 
 
-# --- PicItem ---
-# 1. Is a dataclass
-# 2. Is frozen
-# 3. Is subclass of Item
-# 4. Has field `format` of type `str`
-# 5. Has field `width` of type `int`
-# 6. Has field `height` of type `int`
-# 7. Inherits all Item fields
-# 8. Can instantiate with all required fields
+class TestLinkItem:
+    """Test LinkItem subclass type of Item content"""
+
+    def test_instance_dataclass(self):
+        """Is a dataclass"""
+        assert is_dataclass(LinkItem)
+
+    def test_subclass_of_item(self):
+        """Subclass of Item"""
+        assert issubclass(LinkItem, Item)
+
+    @pytest.mark.parametrize(_ITEM_PARAM_NAMES, [("url", str, True, None)])
+    def test_fields(self, name, typ, required, default):
+        """Test name, type, optionality, default value of all fields"""
+        _assert_field(LinkItem, name, typ, required, default)
+
+    @pytest.mark.parametrize(_ITEM_PARAM_NAMES, _ITEM_PARAMS)
+    def test_inherits_item_fields(self, name, typ, required, default):
+        """Inherits all Item field specifications from subclass"""
+        _assert_field(LinkItem, name, typ, required, default)
+
+    def test_instantiate(self):
+        """Can instantiate with all requried fields"""
+        linkitem = make_link_item()
+        assert linkitem.code == "ABC12345"
+        assert linkitem.url == "https://example.com"
+
+    def test_frozen(self):
+        """Is frozen (immutable)"""
+        linkitem = make_link_item()
+        with pytest.raises(FrozenInstanceError):
+            linkitem.code = "F00BAR"  # pyright: ignore[reportAttributeAccessIssue] noqa
 
 
-# --- LinkItem ---
-# 1. Is a dataclass
-# 2. Is frozen
-# 3. Is subclass of Item
-# 4. Has field `url` of type `str`
-# 5. Inherits all Item fields
-# 6. Can instantiate with all required fields
+class TestPicItem:
+    """Test PicItem subclass type of Item content"""
+
+    def test_instance_dataclass(self):
+        """Is a dataclass"""
+        assert is_dataclass(PicItem)
+
+    def test_subclass_of_item(self):
+        """Subclass of Item"""
+        assert issubclass(PicItem, Item)
+
+    @pytest.mark.parametrize(
+        _ITEM_PARAM_NAMES,
+        [
+            ("format", str, True, None),
+            ("width", int, True, None),
+            ("height", int, True, None),
+        ],
+    )
+    def test_fields(self, name, typ, required, default):
+        """Test name, type, optionality, default value of all fields"""
+        _assert_field(PicItem, name, typ, required, default)
+
+    @pytest.mark.parametrize(_ITEM_PARAM_NAMES, _ITEM_PARAMS)
+    def test_inherits_item_fields(self, name, typ, required, default):
+        """Inherits all Item field specifications from subclass"""
+        _assert_field(PicItem, name, typ, required, default)
+
+    def test_instantiate(self):
+        """Can instantiate with all requried fields"""
+        linkitem = make_link_item()
+        assert linkitem.code == "ABC12345"
+        assert linkitem.url == "https://example.com"
+
+    def test_frozen(self):
+        """Is frozen (immutable)"""
+        picitem = make_pic_item()
+        with pytest.raises(FrozenInstanceError):
+            picitem.code = "F00BAR"  # pyright: ignore[reportAttributeAccessIssue] noqa

--- a/tests/model/test_item.py
+++ b/tests/model/test_item.py
@@ -2,18 +2,19 @@
 # tests depo.model.item
 # Marcus Grant 2026-01-19
 
-from dataclasses import MISSING, FrozenInstanceError, fields, is_dataclass
+from dataclasses import FrozenInstanceError, is_dataclass
 
 import pytest
 from tests.factories import make_item, make_link_item, make_pic_item, make_text_item
+from tests.helpers import assert_field
 
 from depo.model.enums import ItemKind, Visibility
 from depo.model.item import Item, LinkItem, PicItem, TextItem
 
-# Used to verify field specifications
-# "name": field name, "typ": type (avoid py keyword),
+# Used to verify Item field specifications
+# Pulled out for reuse because subtypes need to check inheritance of these fields
+# "name": field name, "typ": type (avoid py keyword 'type'),
 # "required": non-optional, "default": default value
-_ITEM_PARAM_NAMES = ("name", "typ", "required", "default")
 _ITEM_PARAMS = [
     ("code", str, True, None),
     ("hash_rest", str, True, None),
@@ -26,18 +27,6 @@ _ITEM_PARAMS = [
 ]
 
 
-# TODO: Refactor with this assetion helper:
-def _assert_field(cls, name, typ, required, default):
-    field_map = {f.name: f for f in fields(cls)}
-    assert name in field_map, f"missing field: {name}"
-    f = field_map[name]
-    assert f.type is typ, f"{name} type mismatch"
-    if required:
-        assert f.default is MISSING, f"{name} should be required"
-    else:
-        assert f.default == default, f"{name} default val mismatch"
-
-
 class TestItem:
     """Tests for the Item model class"""
 
@@ -45,10 +34,10 @@ class TestItem:
         """Is a dataclass"""
         assert is_dataclass(Item)
 
-    @pytest.mark.parametrize(_ITEM_PARAM_NAMES, _ITEM_PARAMS)
+    @pytest.mark.parametrize("name,typ,required,default", _ITEM_PARAMS)
     def test_fields(self, name, typ, required, default):
         """Test name, type, optionality, default value of all fields"""
-        _assert_field(Item, name, typ, required, default)
+        assert_field(Item, name, typ, required, default)
 
     def test_frozen(self):
         """Is frozen (immutable)."""
@@ -68,15 +57,17 @@ class TestTextItem:
         """Is a subclass of Item"""
         assert issubclass(TextItem, Item)
 
-    @pytest.mark.parametrize(_ITEM_PARAM_NAMES, [("format", str, False, "txt")])
+    @pytest.mark.parametrize(
+        "name,typ,required,default", [("format", str, False, "txt")]
+    )
     def test_fields(self, name, typ, required, default):
         """Test name, type, optionality, default value of all fields"""
-        _assert_field(TextItem, name, typ, required, default)
+        assert_field(TextItem, name, typ, required, default)
 
-    @pytest.mark.parametrize(_ITEM_PARAM_NAMES, _ITEM_PARAMS)
+    @pytest.mark.parametrize("name,typ,required,default", _ITEM_PARAMS)
     def test_inherits_item_fields(self, name, typ, required, default):
         """Inherits all Item field specifications"""
-        _assert_field(TextItem, name, typ, required, default)
+        assert_field(TextItem, name, typ, required, default)
 
     def test_frozen(self):
         """Is frozen (immutable)"""
@@ -102,15 +93,15 @@ class TestLinkItem:
         """Subclass of Item"""
         assert issubclass(LinkItem, Item)
 
-    @pytest.mark.parametrize(_ITEM_PARAM_NAMES, [("url", str, True, None)])
+    @pytest.mark.parametrize("name,typ,required,default", [("url", str, True, None)])
     def test_fields(self, name, typ, required, default):
         """Test name, type, optionality, default value of all fields"""
-        _assert_field(LinkItem, name, typ, required, default)
+        assert_field(LinkItem, name, typ, required, default)
 
-    @pytest.mark.parametrize(_ITEM_PARAM_NAMES, _ITEM_PARAMS)
+    @pytest.mark.parametrize("name,typ,required,default", _ITEM_PARAMS)
     def test_inherits_item_fields(self, name, typ, required, default):
         """Inherits all Item field specifications from subclass"""
-        _assert_field(LinkItem, name, typ, required, default)
+        assert_field(LinkItem, name, typ, required, default)
 
     def test_instantiate(self):
         """Can instantiate with all requried fields"""
@@ -137,7 +128,7 @@ class TestPicItem:
         assert issubclass(PicItem, Item)
 
     @pytest.mark.parametrize(
-        _ITEM_PARAM_NAMES,
+        "name,typ,required,default",
         [
             ("format", str, True, None),
             ("width", int, True, None),
@@ -146,12 +137,12 @@ class TestPicItem:
     )
     def test_fields(self, name, typ, required, default):
         """Test name, type, optionality, default value of all fields"""
-        _assert_field(PicItem, name, typ, required, default)
+        assert_field(PicItem, name, typ, required, default)
 
-    @pytest.mark.parametrize(_ITEM_PARAM_NAMES, _ITEM_PARAMS)
+    @pytest.mark.parametrize("name,typ,required,default", _ITEM_PARAMS)
     def test_inherits_item_fields(self, name, typ, required, default):
         """Inherits all Item field specifications from subclass"""
-        _assert_field(PicItem, name, typ, required, default)
+        assert_field(PicItem, name, typ, required, default)
 
     def test_instantiate(self):
         """Can instantiate with all requried fields"""

--- a/tests/model/test_write_plan.py
+++ b/tests/model/test_write_plan.py
@@ -1,0 +1,71 @@
+# tests/model/test_write_plan.py
+
+"""
+Test specifications for WritePlan DTO.
+
+Verifies dataclass behavior, immutability, and field definitions.
+WritePlan is the handoff between IngestService and Repository.
+
+Author: Marcus Grant
+Date: 2026-01-19
+License: Apache-2.0
+"""
+
+from dataclasses import FrozenInstanceError, is_dataclass
+from pathlib import Path
+
+import pytest
+from tests.factories import make_write_plan
+from tests.helpers import assert_field
+
+from depo.model.enums import ItemKind, PayloadKind
+from depo.model.write_plan import WritePlan
+
+
+class TestWritePlan:
+    """Test the WritePlan DTO class passesd from IngestService & Repository"""
+
+    def test_is_dataclass(self):
+        """Is a dataclass"""
+        assert is_dataclass(WritePlan)
+
+    @pytest.mark.parametrize(
+        ("name", "typ", "required", "default"),
+        # (field name, type, required?, default value)
+        [
+            ("hash_full", str, True, None),
+            ("code_min_len", int, True, None),
+            ("payload_kind", PayloadKind, True, None),
+            ("payload_bytes", bytes | None, False, None),
+            ("payload_path", Path | None, False, None),
+            ("kind", ItemKind, True, None),
+            ("mime", str, True, None),
+            ("size_b", int, True, None),
+            ("upload_at", int, True, None),
+            ("origin_at", int | None, False, None),
+            ("text_format", str | None, False, None),
+            ("pic_format", str | None, False, None),
+            ("pic_width", int | None, False, None),
+            ("pic_height", int | None, False, None),
+            ("link_url", str | None, False, None),
+        ],
+    )
+    def test_fields(self, name, typ, required, default):
+        """Test specs of class dataclass fields"""
+        assert_field(WritePlan, name, typ, required, default)
+
+    def test_instantiate_requried_fields(self):
+        """Instantiates with only required fields"""
+        # See tests.factories.make_write_plan for default factory field values
+        write_plan = make_write_plan(hash_full="F00BAR12")
+        assert write_plan.hash_full == "F00BAR12"
+        assert write_plan.code_min_len == 8
+        assert write_plan.upload_at == 1234567890
+        assert write_plan.origin_at is None
+        assert write_plan.payload_path is None
+
+    def test_frozen(self):
+        """Is frozen (immutable)"""
+        write_plan = make_write_plan()
+        with pytest.raises(FrozenInstanceError):
+            write_plan.hash_full = "F00BAR12"  # pyright: ignore[reportAttributeAccessIssue] noqa

--- a/uv.lock
+++ b/uv.lock
@@ -65,6 +65,7 @@ dev = [
     { name = "black" },
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-xdist" },
     { name = "ruff" },
 ]
 
@@ -75,7 +76,17 @@ dev = [
     { name = "black", specifier = ">=24.0" },
     { name = "mypy", specifier = ">=1.10" },
     { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-xdist" },
     { name = "ruff", specifier = ">=0.6" },
+]
+
+[[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
 ]
 
 [[package]]
@@ -240,6 +251,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Adds the model/ layer — pure Python domain types with no I/O dependencies.

## Contents
- Enums: ItemKind, PayloadKind, Visibility (StrEnum, ≤5 char values)
- Domain models: Item base + TextItem, PicItem, LinkItem subtypes
- WritePlan DTO for ingest-to-repository handoff

## Design decisions
- Frozen dataclasses with `kw_only=True` for inheritance
- Flat domain models (repo hides table joins)
- Storage path derived from code + mime (no `store_key`)
- Timestamps: `upload_at` (required), `origin_at` (optional)

## Test support
- Factories: `make_item`, `make_text_item`, `make_pic_item`, `make_link_item`, `make_write_plan`
- Helpers: `assert_field` for dataclass field specs 
