### PR TITLE
Ref: Replace MIME with ContentFormat enum

### DIFF
--- a/doc/module/model.md
+++ b/doc/module/model.md
@@ -6,28 +6,36 @@ Domain models, DTOs, and enums. Pure Python with no I/O dependencies.
 
 | Enum | Members | Stored in DB |
 |------|---------|--------------|
-| ItemKind | TEXT, IMAGE, LINK | Yes |
+| ItemKind | TEXT, PICTURE, LINK | Yes |
 | Visibility | PRIVATE, UNLISTED, PUBLIC | Yes |
 | PayloadKind | BYTES, FILE | No |
+| ContentFormat | TXT, MD, PY, JSON, YAML, PNG, JPG, WEBP, GIF, SVG, ... | Yes |
 
-All use StrEnum with \u22645 char values.
+All use StrEnum. ItemKind/Visibility/PayloadKind values ≤5 chars.
+ContentFormat values are canonical short extensions (e.g., `jpg` not `jpeg`).
 
 ## item.py
 
 Frozen dataclasses with `kw_only=True`.
 
-**Item (base):** code, hash_rest, kind, mime, size_b, upload_at, uid, perm, origin_at (optional)
+**Item (base):** code, hash_rest, kind, size_b, upload_at, uid, perm, origin_at (optional)
 
-**TextItem(Item):** format
+**TextItem(Item):** format (ContentFormat)
 
-**PicItem(Item):** format, width, height
+**PicItem(Item):** format (ContentFormat), width, height
 
 **LinkItem(Item):** url
+
+Note: `mime` is not stored. MIME is derived from `format` at serve time via `util/formats.py`.
 
 ## write_plan.py
 
 Frozen DTO for ingest-to-repository handoff.
 
-**Required:** hash_full, code_min_len, payload_kind, kind, mime, size_b, upload_at
+**Required:** hash_full, code_min_len, payload_kind, kind, size_b, upload_at
 
-**Optional:** origin_at, payload_bytes, payload_path, text_format, pic_format, pic_width, pic_height, link_url
+**Optional:** format, origin_at, payload_bytes, payload_path, width, height, link_url
+
+>Note: `format` is None only for LinkItem.
+>Image dimensions (width, height) are top-level, not prefixed.
+

--- a/src/depo/model/enums.py
+++ b/src/depo/model/enums.py
@@ -1,19 +1,57 @@
 # src/depo/model/enums.py
+"""
+Enums for domain models and DTOs.
+
+StrEnum subclasses with short values for database storage.
+ContentFormat values are canonical extensions used for storage paths
+and format identification. MIME types are derived at serve time.
+
+Author: Marcus Grant
+Date: 2026-01-20
+License: Apache-2.0
+"""
+
 from enum import StrEnum
 
 
 class ItemKind(StrEnum):
+    """Content type discriminator for Item subtypes."""
+
     TEXT = "txt"
     LINK = "url"
     PICTURE = "pic"
 
 
 class Visibility(StrEnum):
+    """Access control level for items."""
+
     UNLISTED = "unl"
     PRIVATE = "prv"
     PUBLIC = "pub"
 
 
 class PayloadKind(StrEnum):
+    """Payload source indicator for WritePlan.
+
+    Tells downstream code whether to read from bytes in memory
+    or from a file path on disk. Transient; not stored in DB.
+    """
+
     BYTES = "byte"
     FILE = "file"
+
+
+class ContentFormat(StrEnum):
+    """Canonical content formats for supported file types.
+
+    Values are short extensions used for storage paths and format
+    identification. MIME types are derived at serve time via util/formats.py.
+    """
+
+    PLAINTEXT = "txt"
+    MARKDOWN = "md"
+    JSON = "json"
+    YAML = "yaml"
+    PNG = "png"
+    JPEG = "jpg"
+    WEBP = "webp"

--- a/src/depo/model/item.py
+++ b/src/depo/model/item.py
@@ -13,9 +13,7 @@ License: Apache-2.0
 
 from dataclasses import dataclass
 
-from depo.model.enums import ItemKind, Visibility
-
-# TODO: Create enums for formats and mimes
+from depo.model.enums import ContentFormat, ItemKind, Visibility
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -23,7 +21,6 @@ class Item:
     code: str
     hash_rest: str
     kind: ItemKind
-    mime: str
     size_b: int
     uid: int
     perm: Visibility
@@ -40,7 +37,7 @@ class TextItem(Item):
     Format field determines rendering behavior on /info.
     """
 
-    format: str = "txt"  # plaintext if nothing specified
+    format: ContentFormat = ContentFormat.PLAINTEXT
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -64,6 +61,6 @@ class PicItem(Item):
     Dimensions required; EXIF support deferred.
     """
 
-    format: str
+    format: ContentFormat
     width: int
     height: int

--- a/src/depo/model/write_plan.py
+++ b/src/depo/model/write_plan.py
@@ -13,7 +13,7 @@ License: Apache-2.0
 from dataclasses import dataclass
 from pathlib import Path
 
-from depo.model.enums import ItemKind, PayloadKind
+from depo.model.enums import ContentFormat, ItemKind, PayloadKind
 
 
 @dataclass(frozen=True)
@@ -22,14 +22,12 @@ class WritePlan:
     code_min_len: int
     payload_kind: PayloadKind
     kind: ItemKind
-    mime: str
     size_b: int
     upload_at: int
+    format: ContentFormat | None = None
     origin_at: int | None = None
     payload_bytes: bytes | None = None
     payload_path: Path | None = None
-    text_format: str | None = None
+    width: int | None = None
+    height: int | None = None
     link_url: str | None = None
-    pic_format: str | None = None
-    pic_width: int | None = None
-    pic_height: int | None = None

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -3,7 +3,7 @@
 # Date: 2026-01-09
 # License: Apache-2.0
 
-from depo.model.enums import ItemKind, PayloadKind, Visibility
+from depo.model.enums import ContentFormat, ItemKind, PayloadKind, Visibility
 from depo.model.item import Item, LinkItem, PicItem, TextItem
 from depo.model.write_plan import WritePlan
 
@@ -13,7 +13,6 @@ _ITEM_DEFAULTS = dict(
     code="ABC12345",
     hash_rest="06789DEFGHKMNPQR",
     kind=ItemKind.TEXT,
-    mime="text/plain",
     size_b=100,
     uid=1,
     perm=Visibility.PUBLIC,
@@ -27,14 +26,13 @@ def make_item(**overrides) -> Item:
 
 
 def make_text_item(**overrides) -> TextItem:
-    defaults = _ITEM_DEFAULTS | dict(format="txt")
+    defaults = _ITEM_DEFAULTS | dict(format=ContentFormat.PLAINTEXT)
     return TextItem(**(defaults | overrides))  # pyright: ignore[reportArgumentType]
 
 
 def make_link_item(**overrides) -> LinkItem:
     defaults = _ITEM_DEFAULTS | dict(
         kind=ItemKind.LINK,
-        mime="text/uri-list",
         url="https://example.com",
     )
     return LinkItem(**(defaults | overrides))  # pyright: ignore[reportArgumentType]
@@ -43,8 +41,7 @@ def make_link_item(**overrides) -> LinkItem:
 def make_pic_item(**overrides) -> PicItem:
     defaults = _ITEM_DEFAULTS | dict(
         kind=ItemKind.PICTURE,
-        mime="image/png",
-        format="png",
+        format=ContentFormat.PNG,
         width=320,
         height=240,
     )

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -55,17 +55,15 @@ _WRITE_PLAN_DEFAULTS = dict(
     code_min_len=8,
     payload_kind=PayloadKind.BYTES,
     kind=ItemKind.TEXT,
-    mime="text/plain",
     size_b=100,
     upload_at=1234567890,
+    format=None,
     origin_at=None,
     payload_bytes=None,
     payload_path=None,
-    text_format=None,
+    width=None,
+    height=None,
     link_url=None,
-    pic_format=None,
-    pic_width=None,
-    pic_height=None,
 )
 
 

--- a/tests/model/test_enums.py
+++ b/tests/model/test_enums.py
@@ -1,9 +1,17 @@
-# Tests for depo/model/enums.py
+# tests/model/test_enums.py
+"""
+Tests for depo/model/enums.py.
+
+Author: Marcus Grant
+Date: 2026-01-19
+License: Apache-2.0
+"""
+
 from enum import StrEnum
 
 import pytest
 
-from depo.model.enums import ItemKind, PayloadKind, Visibility
+from depo.model.enums import ContentFormat, ItemKind, PayloadKind, Visibility
 
 
 class TestItemKind:
@@ -52,12 +60,6 @@ class TestVisibility:
         assert member == val
 
 
-# PayloadKind
-#
-# - Has exactly two members
-# - BYTES member exists with value "bytes"
-# - FILE member exists with value "file"
-# - Members compare equal to their string values
 class TestPayloadKind:
     """Test PayloadKind enum, gives info on how to handle payload"""
 
@@ -74,6 +76,37 @@ class TestPayloadKind:
     def test_member_key_values(self, key, val):
         """Should have these expected member names"""
         member = PayloadKind[key]
+        assert member.name == key
+        assert member.value == val
+        assert member == val
+
+
+class TestContentFormat:
+    """Tests ContentFormat enum against its supported formats."""
+
+    def test_is_str_enum(self):
+        """Always a StrEnum subclass."""
+        for member in ContentFormat:
+            assert isinstance(member, StrEnum)
+
+    def test_member_count(self):
+        assert len(ContentFormat) == 7
+
+    @pytest.mark.parametrize(
+        "key,val",
+        [
+            ("PLAINTEXT", "txt"),
+            ("MARKDOWN", "md"),
+            ("JSON", "json"),
+            ("YAML", "yaml"),
+            ("PNG", "png"),
+            ("JPEG", "jpg"),
+            ("WEBP", "webp"),
+        ],
+    )
+    def test_member_key_values(self, key, val):
+        """Has these member key/value pairings"""
+        member = ContentFormat[key]
         assert member.name == key
         assert member.value == val
         assert member == val

--- a/tests/model/test_item.py
+++ b/tests/model/test_item.py
@@ -8,7 +8,7 @@ import pytest
 from tests.factories import make_item, make_link_item, make_pic_item, make_text_item
 from tests.helpers import assert_field
 
-from depo.model.enums import ItemKind, Visibility
+from depo.model.enums import ContentFormat, ItemKind, Visibility
 from depo.model.item import Item, LinkItem, PicItem, TextItem
 
 # Used to verify Item field specifications
@@ -19,7 +19,6 @@ _ITEM_PARAMS = [
     ("code", str, True, None),
     ("hash_rest", str, True, None),
     ("kind", ItemKind, True, None),
-    ("mime", str, True, None),
     ("size_b", int, True, None),
     ("uid", int, True, None),
     ("perm", Visibility, True, None),
@@ -59,7 +58,7 @@ class TestTextItem:
         assert issubclass(TextItem, Item)
 
     @pytest.mark.parametrize(
-        "name,typ,required,default", [("format", str, False, "txt")]
+        "name,typ,required,default", [("format", ContentFormat, False, "txt")]
     )
     def test_fields(self, name, typ, required, default):
         """Test name, type, optionality, default value of all fields"""
@@ -80,7 +79,7 @@ class TestTextItem:
         """Can instantiate with all requried fields"""
         textitem = make_text_item()
         assert textitem.code == "ABC12345"
-        assert textitem.format == "txt"
+        assert textitem.format == ContentFormat.PLAINTEXT
 
 
 class TestLinkItem:
@@ -131,7 +130,7 @@ class TestPicItem:
     @pytest.mark.parametrize(
         "name,typ,required,default",
         [
-            ("format", str, True, None),
+            ("format", ContentFormat, True, None),
             ("width", int, True, None),
             ("height", int, True, None),
         ],
@@ -147,9 +146,9 @@ class TestPicItem:
 
     def test_instantiate(self):
         """Can instantiate with all requried fields"""
-        linkitem = make_link_item()
-        assert linkitem.code == "ABC12345"
-        assert linkitem.url == "https://example.com"
+        picitem = make_pic_item(format=ContentFormat.JPEG)
+        assert picitem.code == "ABC12345"
+        assert picitem.format == ContentFormat.JPEG
 
     def test_frozen(self):
         """Is frozen (immutable)"""

--- a/tests/model/test_write_plan.py
+++ b/tests/model/test_write_plan.py
@@ -18,7 +18,7 @@ import pytest
 from tests.factories import make_write_plan
 from tests.helpers import assert_field
 
-from depo.model.enums import ItemKind, PayloadKind
+from depo.model.enums import ContentFormat, ItemKind, PayloadKind
 from depo.model.write_plan import WritePlan
 
 
@@ -39,14 +39,12 @@ class TestWritePlan:
             ("payload_bytes", bytes | None, False, None),
             ("payload_path", Path | None, False, None),
             ("kind", ItemKind, True, None),
-            ("mime", str, True, None),
+            ("format", ContentFormat | None, False, None),
             ("size_b", int, True, None),
             ("upload_at", int, True, None),
             ("origin_at", int | None, False, None),
-            ("text_format", str | None, False, None),
-            ("pic_format", str | None, False, None),
-            ("pic_width", int | None, False, None),
-            ("pic_height", int | None, False, None),
+            ("width", int | None, False, None),
+            ("height", int | None, False, None),
             ("link_url", str | None, False, None),
         ],
     )


### PR DESCRIPTION
- Consolidate `mime`/`text_format`/`pic_format`...
  ... into single ContentFormat enum
- MIME types are now derived at serve time, not stored.
- Once through the upcoming IngestService...
  - no longer need to track MIME type, ContentFormat has enough info
- ContentFormat now a canonical EnumStr for all supported formats
- Remove mime field from Item base class
- TextItem/PicItem use format: ContentFormat
- Update docs, factories and tests reflecting consolidation
