### PR TITLE
Ft: HTMX file upload path

### DIFF
--- a/doc/design/routes.md
+++ b/doc/design/routes.md
@@ -13,7 +13,9 @@ These negotiate request context and delegate to a specific handler.
   - Browser gets info page, API gets raw content.
   - LinkItem always redirects (302) regardless of context.
 - `GET /{code}/info` - `info()`. Delegates to `page_info`, `hx_info`, or `api_info`.
-- `POST /upload` - `upload()`. Delegates to `hx_upload` or `api_upload`.
+- `POST /upload` - `upload()`
+  - Delegates to `hx_upload` or `api_upload`.
+  - Also handles multipart form data & file uploads with file upload element.
 
 ### Single-context routes
 
@@ -26,6 +28,7 @@ These negotiate request context and delegate to a specific handler.
   - Register before `/{code}` to prevent wildcard swallowing.
 - `GET /upload` - `page_upload()`.
   - Upload form, full page render.
+  - File picker embedded into text area to drop files or click to pick.
 - `GET /health` - `health()`.
   - Liveness probe.
 

--- a/doc/module/templates.md
+++ b/doc/module/templates.md
@@ -7,9 +7,12 @@ Rendered by `web.templates.get_templates()`.
 
 ```txt
 templates/
-├── base.html                # Full page layout wrapper
-├── upload.html              # Upload form (extends base.html)
+├── base.html                # Full page layout wrapper, defines scripts block
 ├── theme.html               # Living style reference (extends base.html)
+├── upload/
+│   ├── page.html            # Upload form (extends base.html)
+│   ├── formats.html         # Format select optgroups (included by page)
+│   └── script.html          # File upload JS (included via scripts block)
 ├── info/
 │   ├── page.html            # Shared info page shell (extends base.html)
 │   ├── link.html            # LinkItem view (extends page.html)
@@ -29,7 +32,10 @@ templates/
 
 ```txt
 base.html
-├── upload.html
+├── upload/
+│   ├── page.html
+│   ├── formats.html
+│   └── script.html
 ├── theme.html
 ├── info/page.html
 │   ├── info/link.html
@@ -48,6 +54,11 @@ window container, shortcode heading, action row,
 payload block, divider, metadata block.
 Child templates fill:
 `{% block payload %}`, `{% block metadata %}`, and `{% block payload_class %}`.
+
+Same pattern repeated for the upload page.
+The `templates/upload` directory contains everything for that page.
+Then the `page.html` defines the main template for that page.
+It includes partials included to split up the markup and scripts.
 
 ## Info page system
 

--- a/doc/planning/mvp.md
+++ b/doc/planning/mvp.md
@@ -32,18 +32,6 @@ Ordered by dependency. Each heading is roughly one PR.
 
 ### Browser UI and styling
 
-- Image upload path (own PR)
-  - NOTE: Some of these need to be considered if they will make it in
-    - We can't clutter the interface too much
-    - We also can't be implementing complicated UIs yet either
-    - Follow the principle of progressive complexity from the user perspective
-  - Hidden file input triggered by label icon in textarea corner
-  - Drag-and-drop handler on textarea for file drops
-  - Paste handler on textarea for clipboard images
-  - Switch form to multipart/form-data when file detected
-  - Upload route accepts UploadFile for binary payloads
-  - Preview card above textarea when image attached
-  - Auto-detect format from file metadata
 - Visual refinement pass (own PR):
   - Specific visual refinmenets:
     - element spacing

--- a/src/depo/templates/base.html
+++ b/src/depo/templates/base.html
@@ -16,6 +16,7 @@
       {% endblock %}
     </main>
     {% include 'partials/foot.html' %}
+    {% block scripts %}{% endblock %}
   </body>
 </html>
 <!-- END: base.html -->

--- a/src/depo/templates/info/page.html
+++ b/src/depo/templates/info/page.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block content %}
-<!-- BEGIN: info/page.html -->
+<!-- BEGIN: info/page.html#content -->
 <!-- EXTENDS: base.html -->
 <article class="window shadow-md">
   <h2 class="shortcode">{{ item.code | upper }}</h2>
@@ -21,7 +21,12 @@
     {% endblock %}
   </dl>
 </article>
+<!-- END: info/page.html#content -->
+{% endblock %}
 <!-- TODO: Does base.html need a scripts block? -->
+{% block scripts %}
+<!-- BEGIN: info/page.html#scripts -->
+<!-- EXTENDS: base.html -->
 <script>
   document.addEventListener('click', async (e) => {
     const btn = e.target.closest('button[data-copy], button[data-copy-url]');
@@ -40,5 +45,5 @@
     }
   });
 </script>
-<!-- END: info/page.html -->
+<!-- END: info/page.html#scripts -->
 {% endblock %}

--- a/src/depo/templates/upload.html
+++ b/src/depo/templates/upload.html
@@ -4,6 +4,14 @@
 <!-- EXTENDS: base.html -->
 <div class="window shadow-md">
   <form method="post" action="/upload" hx-post="/upload" hx-target="#result" hx-swap="innerHTML">
+    <input type="file" name="file" id="file-input" hidden>
+    <label for="file-input" class="file-input-label">Add File</label>
+    <div class="attachment-card" hidden>
+      <img class="attachment-preview" hidden>
+      <span class="attachment-name"></span>
+      <span class="attachment-size"></span>
+      <button type="button" class="attachment-clear">✕</button>
+    </div>
     <textarea name="content"></textarea>
     <div class="window-controls">
       <select name="format">

--- a/src/depo/templates/upload/format-select.html
+++ b/src/depo/templates/upload/format-select.html
@@ -1,0 +1,23 @@
+<!-- BEGIN: upload/format-select.html -->
+<div class="window-controls">
+  <select name="format">
+    <option value="" selected>Auto-detect</option>
+    <optgroup label="Link">
+      <option value="url">URL</option>
+    </optgroup>
+    <optgroup label="Text">
+      <option value="txt">Plain Text</option>
+      <option value="md">Markdown</option>
+      <option value="json">JSON</option>
+      <option value="yaml">YAML</option>
+    </optgroup>
+    <optgroup label="Image">
+      <option value="jpg">JPEG</option>
+      <option value="png">PNG</option>
+      <option value="webp">WebP</option>
+      <option value="tiff">TIFF</option>
+    </optgroup>
+  </select>
+  <button type="submit">Record</button>
+</div>
+<!-- END: upload/format-select.html -->

--- a/src/depo/templates/upload/page.html
+++ b/src/depo/templates/upload/page.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+{% block content %}
+<!-- BEGIN: upload/page.html#content -->
+<!-- EXTENDS: base.html -->
+<div class="window shadow-md">
+  <form method="post" action="/upload" hx-post="/upload" hx-target="#result" hx-swap="innerHTML">
+    <input type="file" name="file" id="file-input" hidden>
+    <label for="file-input" class="file-input-label">Add File</label>
+    <div class="attachment-card" hidden>
+      <img class="attachment-preview" hidden>
+      <span class="attachment-name"></span>
+      <span class="attachment-size"></span>
+      <button type="button" class="attachment-clear">✕</button>
+    </div>
+    <textarea name="content"></textarea>
+    {% include 'upload/format-select.html' %}
+  </form>
+</div>
+<div id="result"></div>
+<!-- END: upload/page.html#content -->
+{% endblock %}
+{% block scripts %}
+<!-- BEGIN: upload/page.html#scripts -->
+<!-- EXTENDS: base.html -->
+{% include 'upload/script.html' %}
+<!-- BEGIN: upload/page.html#scripts -->
+{% endblock %}

--- a/src/depo/templates/upload/script.html
+++ b/src/depo/templates/upload/script.html
@@ -1,45 +1,4 @@
-{% extends "base.html" %}
-{% block content %}
-<!-- BEGIN: upload.html#content -->
-<!-- EXTENDS: base.html -->
-<div class="window shadow-md">
-  <form method="post" action="/upload" hx-post="/upload" hx-target="#result" hx-swap="innerHTML">
-    <input type="file" name="file" id="file-input" hidden>
-    <label for="file-input" class="file-input-label">Add File</label>
-    <div class="attachment-card" hidden>
-      <img class="attachment-preview" hidden>
-      <span class="attachment-name"></span>
-      <span class="attachment-size"></span>
-      <button type="button" class="attachment-clear">✕</button>
-    </div>
-    <textarea name="content"></textarea>
-    <div class="window-controls">
-      <select name="format">
-    <option value="" selected>Auto-detect</option>
-    <optgroup label="Link">
-      <option value="url">URL</option>
-    </optgroup>
-    <optgroup label="Text">
-      <option value="txt">Plain Text</option>
-      <option value="md">Markdown</option>
-      <option value="json">JSON</option>
-      <option value="yaml">YAML</option>
-    </optgroup>
-    <optgroup label="Image">
-      <option value="jpg">JPEG</option>
-      <option value="png">PNG</option>
-      <option value="webp">WebP</option>
-      <option value="tiff">TIFF</option>
-    </optgroup>
-    </select>
-      <button type="submit">Record</button>
-    </div>
-  </form>
-</div>
-<div id="result"></div>
-<!-- END: upload.html#content -->
-{% endblock %}
-{% block scripts %}
+<!-- BEGIN: upload/script.html -->
 <script>
 (function () {
   const form = document.querySelector('form');
@@ -60,6 +19,7 @@
 
   function attachFile(file) {
     form.enctype = 'multipart/form-data';
+    form.setAttribute('hx-encoding', 'multipart/form-data');
     textarea.hidden = true;
     card.hidden = false;
     nameEl.textContent = file.name;
@@ -117,6 +77,7 @@
   clearBtn.addEventListener('click', () => {
     fileInput.value = '';
     form.enctype = 'application/x-www-form-urlencoded';
+    form.removeAttribute('hx-encoding');
     textarea.hidden = false;
     textarea.value = '';
     card.hidden = true;
@@ -125,4 +86,4 @@
   });
 })();
 </script>
-{% endblock %}
+<!-- END: upload/scripts.html -->

--- a/src/depo/web/routes/upload.py
+++ b/src/depo/web/routes/upload.py
@@ -14,6 +14,7 @@ from typing import TypedDict
 
 from fastapi import APIRouter, Depends, Query, Request, Response, UploadFile
 from fastapi.responses import HTMLResponse, PlainTextResponse, RedirectResponse
+from starlette.datastructures import UploadFile as StarletteUploadFile
 
 from depo.model.enums import ContentFormat
 from depo.model.item import LinkItem
@@ -125,6 +126,7 @@ class UploadFormParams(TypedDict):
 
     payload_bytes: bytes
     declared_mime: str
+    filename: str | None
     requested_format: ContentFormat | None
 
 
@@ -165,12 +167,21 @@ async def _parse_form_upload(
     """Extract orchestrator.ingest kwargs from browser form submission."""
     form = await req.form()
     content = str(form.get("content", "")).strip()
+    file = form.get("file")
     fmt = str(form.get("format", ""))
+    if isinstance(file, StarletteUploadFile) and (data := await file.read()):
+        return UploadFormParams(
+            payload_bytes=data,
+            declared_mime=file.content_type or "application/octet-stream",
+            filename=file.filename,
+            requested_format=ContentFormat(fmt) if fmt else None,
+        )
     if not content:
         raise ValueError("No content provided.")
     return UploadFormParams(
         payload_bytes=content.encode("utf-8"),
         declared_mime="text/plain",
+        filename=None,
         requested_format=ContentFormat(fmt) if fmt else None,
     )
 

--- a/src/depo/web/routes/upload.py
+++ b/src/depo/web/routes/upload.py
@@ -30,7 +30,7 @@ _templates = get_templates()  # Preload templates for route handlers
 @upload_router.get("/upload")
 async def page_upload(req: Request):
     """Serve the upload form as a full HTML page."""
-    return get_templates().TemplateResponse(request=req, name="upload.html")
+    return get_templates().TemplateResponse(request=req, name="upload/page.html")
 
 
 @upload_router.post("/upload", status_code=201)

--- a/tests/web/routes/test_upload.py
+++ b/tests/web/routes/test_upload.py
@@ -206,6 +206,15 @@ class TestHtmxUploadSuccess:
         assert "<!-- BEGIN: base.html -->" not in resp.text
         assert "<!-- BEGIN: partials/success.html" in resp.text
 
+    def test_file_upload_returns_shortcode(self, t_htmx):
+        """File upload via form returns success partial with shortcode."""
+        img, data = gen_image("jpeg", 16, 16), {"content": "", "format": ""}
+        files = {"file": ("photo.jpg", img, "image/jpeg")}
+        resp = t_htmx.post("/upload", data=data, files=files)
+        assert resp.status_code == 200
+        code = BeautifulSoup(resp.text, "html.parser").find("code", class_="shortcode")
+        assert code is not None
+
 
 class TestHtmxUploadError:
     """POST /upload with HX-Request returns error partial on failure."""
@@ -276,6 +285,24 @@ class TestParseFormUpload:
         req.form = AsyncMock(return_value={"content": content, "format": fmt})
         return dict(await _parse_form_upload(req))
 
+    async def _file_fn(
+        self,
+        data: bytes = b"\xff\xd8\xff\xe0",
+        ctype: str = "image/jpeg",
+        filename: str = "photo.jpg",
+        content: str = "",
+        fmt: str = "",
+    ) -> dict:
+        file = MagicMock(spec=UploadFile)
+        file.read = AsyncMock(return_value=data)
+        file.content_type = ctype
+        file.filename = filename
+        file.size = len(data)
+        form = {"content": content, "format": fmt, "file": file}
+        req = MagicMock()
+        req.form = AsyncMock(return_value=form)
+        return dict(await _parse_form_upload(req))
+
     async def test_textarea_content_extracts_payload(self):
         """Textarea content is extracted as payload_bytes."""
         result = await self._test_fn("hello", "")
@@ -298,6 +325,23 @@ class TestParseFormUpload:
         """Empty or whitespace-only textarea raises ValueError."""
         with pytest.raises(ValueError, match="No content provided"):
             await self._test_fn(content, "")
+
+    async def test_file_extracts_fields(self):
+        """File bytes, content_type, and filename are extracted."""
+        result = await self._file_fn()
+        assert result["payload_bytes"] == b"\xff\xd8\xff\xe0"
+        assert result["declared_mime"] == "image/jpeg"
+        assert result["filename"] == "photo.jpg"
+
+    async def test_file_preferred_over_textarea(self):
+        """File takes precedence when both content and file present."""
+        result = await self._file_fn(content="leftover text")
+        assert result["payload_bytes"] == b"\xff\xd8\xff\xe0"
+
+    async def test_empty_file_raises(self):
+        """Empty file raises ValueError."""
+        with pytest.raises(ValueError, match="No content provided"):
+            await self._file_fn(data=b"")
 
 
 class TestUploadResponse:

--- a/tests/web/routes/test_upload.py
+++ b/tests/web/routes/test_upload.py
@@ -161,8 +161,8 @@ class TestGetUploadPage:
     def test_returns_expected_html(self, t_client):
         """Returns template markers, form elements & content-type overrides"""
         resp = t_client.get(url="/upload")
-        assert "<!-- BEGIN: upload.html -->" in resp.text
-        assert "<!-- END: upload.html -->" in resp.text
+        assert "<!-- BEGIN: upload/page.html" in resp.text
+        assert "<!-- END: upload/page.html" in resp.text
         soup = BeautifulSoup(resp.text, "html.parser")
         assert soup.find("form", attrs={"method": "post", "action": "/upload"})
         assert soup.find("textarea", attrs={"name": "content"})

--- a/tests/web/routes/test_upload.py
+++ b/tests/web/routes/test_upload.py
@@ -148,6 +148,11 @@ class TestUploadFormat:
 class TestGetUploadPage:
     """GET /upload serves the upload form"""
 
+    def select(self, selector, client):
+        """Test helper requests from /upload and parses using soup selector."""
+        resp = client.get("/upload")
+        return BeautifulSoup(resp.text, "html.parser").select(selector)
+
     def test_returns_200_and_html_content(self, t_client):
         resp = t_client.get(url="/upload")
         assert resp.status_code == 200
@@ -179,6 +184,27 @@ class TestGetUploadPage:
                 options.add(val)
         expected = {f.value for f in ContentFormat}
         assert options == expected, f"Missing: {expected - options}"
+
+    def test_has_file_input(self, t_client):
+        """Form includes a hidden file input for image uploads."""
+        soup = BeautifulSoup(t_client.get("/upload").text, "html.parser")
+        finput = soup.find("input", attrs={"type": "file", "name": "file"})
+        assert finput is not None
+        hidden, style = finput.get("hidden"), finput.get("style") == "display:none"
+        assert (hidden is not None) or (style == "display:none")
+
+    def test_has_file_input_label(self, t_client):
+        """Form has a visible label triggering the file input."""
+        soup = BeautifulSoup(t_client.get("/upload").text, "html.parser")
+        finput = soup.find("input", attrs={"type": "file", "name": "file"})
+        label = soup.find("label", attrs={"for": finput.get("id")})  # type:ignore
+        assert label is not None
+
+    def test_has_attachment_card(self, t_client):
+        """Form includes an attachment preview container, hidden by default."""
+        soup = BeautifulSoup(t_client.get("/upload").text, "html.parser")
+        card = soup.find(class_="attachment-card")
+        assert card is not None
 
 
 class TestHtmxUploadSuccess:


### PR DESCRIPTION
Browser file upload support for the HTMX upload form.

- Form file field parsing in _parse_form_upload
  - StarletteUpload isinstance guard, file preferred over textarea
  - filename added to UploadFormParams
- Upload template restructured to upload/ directory
  - page.html, formats.html (select optgroups), script.html (JS)
  - scripts block added to base.html, info/page.html migrated
- Upload JS: file picker, paste, drag-and-drop
  - Attachment card with image preview and text snippet
  - hx-encoding switch for HTMX multipart submission
  - Clear button restores textarea
- HTMX file upload end-to-end tested
- Docs updated
