### PR TITLE
ft/visual-refinement: CSS primitives, chrome realignment, info page restructure

### DIFF
--- a/doc/design/language.md
+++ b/doc/design/language.md
@@ -300,6 +300,38 @@ full page loads receive wrapped templates.
 Shortcodes displayed with `<code class="shortcode">`;
 functional class, tested against.
 
+### Info page structure
+
+The `/info` route is a record inspection view, not a content viewer.
+Canonical layout:
+
+```text
+    reference (shortcode)
+    record actions
+    metadata
+    — divider —
+    payload actions
+    payload
+```
+
+Record actions operate on the record as a whole (Copy Link, View Raw).
+Payload actions operate on the payload only (Copy Content).
+Actions live adjacent to the object they affect.
+`View Raw` is an anchor styled as a secondary button.
+
+### Structural classes
+
+`.action-row` — record-level action strip below the reference.
+`.payload-actions` — payload-level action strip directly above payload.
+These are intentionally separate; do not merge them into a single toolbar.
+
+### Deferred endpoints
+
+`/render` — clean presentation view for payload content; minimal UI;
+optimized for reading. Resolves tension between record inspection
+(`/info`) and content viewing. `/raw` remains literal stored payload.
+Not required pre-MVP.
+
 ## How to evolve this document
 
 Design decisions are categorized as:

--- a/doc/design/styles.md
+++ b/doc/design/styles.md
@@ -14,6 +14,10 @@ Fully opaque SVG data URIs, ground `rgb(230,230,230)`, fill `rgb(200,200,200)`.
 
 Structure: `--depo-titlebar-height`, `--depo-bg`, `--depo-border`.
 
+Surfaces: `--depo-surface` (rgb 230, desktop/shell background),
+`--depo-bg` (rgb 245, window surface). `--depo-measure` (48rem, column width).
+Semantic: `--depo-size-code` (1.1rem, reference display size).
+
 ## Class reference
 
 Dither fills: `.dither-diag`, `.dither-check`, `.dither-cross`.
@@ -23,26 +27,29 @@ Form grouping: `.window-controls` (flex row).
 
 ## Shadows
 
-`.shadow-sm` (11px offset), `.shadow-md` (19px offset).
+`.shadow-sm` (4px offset). `.shadow-md` removed.
 Checkerboard `::after` pseudo-element, bordered, `z-index: -1`.
-Stacking context lives on `main`, not the shadow parent.
-`background-position: top left` for bottom-edge tile alignment.
-
-Offsets are manually tuned — border width shifts background origin
-so clean tile multiples don't land. Deeper fix deferred to v0.2.
+Reserved for overlays and inset components only.
+Do not apply to primary page surface.
 
 ## Titlebar
 
-`.titlebar` — flex container with horizontal stripe dither.
-`.titlebar-label` — child `<a>`, stretches to fill bar height,
-solid background punchout matching stripe ground color.
-
-Uses `overflow: hidden` to clip. Height via `--depo-titlebar-height`.
+`.titlebar` — full-width structural band, `border-bottom` only.
+No dither fill. Background matches `--depo-surface`.
+`.titlebar-inner` — constrained to `--depo-measure`, flex row,
+centers content vertically. Used in nav and footer for column alignment.
+Note: `.titlebar-inner` is misnamed as a general layout wrapper;
+rename to `.page-column` post-MVP.
+`.titlebar-label` — plain anchor, no background or punchout styling.
 
 ## Window
 
-`.window` — bordered container, solid `--depo-bg` background.
-Sits on gray `main` surface. Combine with shadow classes for depth.
+`.window` — bordered container, solid `--depo-bg` background, no margin.
+One window per page. Either `main` contains one `.window`, or a component
+is the window — never both.
+`.window--error` — border-color override to `--depo-error`, 4px left accent.
+Used for fatal error pages only. Inline errors use notices, not window variants.
+No shadow on primary page surface. `shadow-sm` reserved for overlays only.
 
 ## Pico override notes
 
@@ -63,3 +70,9 @@ Form element fonts set directly — no Pico property for these.
 High-DPI: 1px SVG bits invisible, `background-size` scaling mandatory.
 Zoom: fractional levels cause sub-pixel artifacts. Clean at 100% and 2x/3x.
 Large-surface dither looked busy — flat grays used instead, dither deferred to v0.2.
+
+`.titlebar-inner` reused as layout column in footer — semantic mismatch,
+rename deferred post-MVP.
+Pico styles `article` element directly (card background, box-shadow,
+padding). Use `article.window` override or avoid `article` for window
+containers.

--- a/doc/planning/mvp.md
+++ b/doc/planning/mvp.md
@@ -32,22 +32,6 @@ Ordered by dependency. Each heading is roughly one PR.
 
 ### Browser UI and styling
 
-- Visual refinement pass (own PR):
-  - Specific visual refinmenets:
-    - element spacing
-    - hierarchy
-    - container proportions
-    - nav/footer tuning
-    - large-surface background treatment
-  - Implement CSS rules for classes in markup:
-    - window--error, action-row,
-    - payload, payload--link/text/pic, divider
-- These next 2 might be better in final preMVP manual test/visual refinement tsk
-  - House cleaning to include:
-    - Split template tests from test_upload.py into test_upload_templates.py
-  - Rename .titlebar-inner to .page-column (or similar): used as a
-    generic layout column wrapper in nav and footer but named after
-    a nav-specific concept; rename for clarity post-MVP
 
 ### Error handling
 
@@ -98,6 +82,12 @@ Minimal auth to prevent open uploads on the public internet.
 
 ### Styling Refinement Pass
 
+- These next 2 might be better in final preMVP manual test/visual refinement tsk
+  - House cleaning to include:
+    - Split template tests from test_upload.py into test_upload_templates.py
+  - Rename .titlebar-inner to .page-column (or similar): used as a
+    generic layout column wrapper in nav and footer but named after
+    a nav-specific concept; rename for clarity post-MVP
 - Success state redesign: replace full-width banner with calm inline
   state near the reference; small label with success hue on text/border
   only; primary action is copy reference; no colored background fill
@@ -113,73 +103,20 @@ Minimal auth to prevent open uploads on the public internet.
 >if overflow occurs in practice, prefer overflow-wrap:
 >anywhere over ellipsis; JS prefix+suffix logic is out of scope pre-MVP
 
-### Global Chrome & Layout Realignment (nav / main / footer / base.html)
-
-**Goal:** Make the overall page shell feel like a single calm system surface.
-Prefer structural honesty (borders, spacing, rhythm) over “window/dialog” cosplay.
-Ensure all hierarchy works in pure grayscale; color remains semantic only.
-
-#### 1) Remove false layering
-
-- Avoid “floating dialog” framing for the primary page surface.
-- Use **one primary containment surface** per page (typically `main`),
-  not nested card/window stacks.
-- Keep `.shadow-*` only where it communicates real stacking
-  - otherwise rely on border + spacing.
-
-#### 2) Establish a stable page frame in `base.html`
-
-- Define one consistent layout grid: `header` (nav), `main`, `footer`.
-- Set a single max-width + horizontal padding rule for `main`
-  - so pages don’t invent their own.
-- Standardize vertical rhythm tokens (one spacing scale); remove ad-hoc micro-gaps.
-
-#### 3) Navbar: structural, not expressive
-
-- Navbar exists to orient, not to brand.
-- Prefer hard bottom border (or separator rule) over decorative fills/texture.
-- Keep height minimal; align content to the same width/padding as `main`.
-- Avoid accent surfaces; no gradients; no ornamental “chrome”.
-
-#### 4) Main backdrop: grayscale-first
-
-- Large surfaces remain grayscale; avoid tinted slabs.
-- Ensure main content boundary reads without color: spacing + borders first.
-- Dark mode parity: invert luminance, keep meaning; do not change hue roles.
-
-#### 5) Footer: quiet + factual
-
-- Footer content in secondary tone; low visual weight.
-- Hard separator above footer if needed; no competing blocks.
-- Align footer width/padding with `main` and navbar.
-
-#### 6) Interaction semantics stay semantic
-
-- Keep warm/cool meaning invariant across the shell:
-  - cool = focus/state
-  - warm = attention/interruption
-  - red = failure only
-- Do not use accent color to “decorate” global chrome.
-
-#### 7) Primitive audit (enforce allowed tools)
-
-- Allowed:
-  - spacing,
-  - typography (mono for identifiers),
-  - weight,
-  - sizing steps,
-  - hard borders,
-  - optional dither separators.
-- Disallowed by default:
-  - blur shadows, gradients, large colored surfaces, decorative textures.
-- If a new visual device is introduced
-  - it must justify itself as structure (not vibe).
-
-#### 8) HTMX compatibility (no layout surprises)
-
-- Shell (`header/main/footer`) should remain stable across HTMX swaps.
-- Swaps should target interior regions only;
-  - avoid global reflow by keeping consistent container widths/padding in `base.html`.
+- Info page header row: merge shortcode and action row into single
+  flex row; shortcode left, record actions right; wrap on narrow
+  viewports
+- View Raw anchor button height: border thickness insufficient to
+  match adjacent button height; fix in final visual refinement pass
+- Reorganize depo.css into logical sections: tokens, base elements,
+  typography, page shell, structural utilities, components,
+  content primitives, upload components
+- Rename .titlebar-inner to .page-column (or similar); currently
+  reused as generic layout column wrapper in nav and footer
+- Upload page window width: too narrow at --depo-measure; needs
+  wider working surface; investigate Pico article/main constraints
+- Convert info page article.window to section.window; article
+  implies self-contained distributable content which is incorrect
 
 ### Manual Testing
 

--- a/doc/planning/mvp.md
+++ b/doc/planning/mvp.md
@@ -42,8 +42,12 @@ Ordered by dependency. Each heading is roughly one PR.
   - Implement CSS rules for classes in markup:
     - window--error, action-row,
     - payload, payload--link/text/pic, divider
-- House cleaning to include:
-  - Split template tests from test_upload.py into test_upload_templates.py
+- These next 2 might be better in final preMVP manual test/visual refinement tsk
+  - House cleaning to include:
+    - Split template tests from test_upload.py into test_upload_templates.py
+  - Rename .titlebar-inner to .page-column (or similar): used as a
+    generic layout column wrapper in nav and footer but named after
+    a nav-specific concept; rename for clarity post-MVP
 
 ### Error handling
 

--- a/doc/planning/mvp.md
+++ b/doc/planning/mvp.md
@@ -42,6 +42,8 @@ Ordered by dependency. Each heading is roughly one PR.
   - Implement CSS rules for classes in markup:
     - window--error, action-row,
     - payload, payload--link/text/pic, divider
+- House cleaning to include:
+  - Split template tests from test_upload.py into test_upload_templates.py
 
 ### Error handling
 
@@ -89,6 +91,23 @@ Minimal auth to prevent open uploads on the public internet.
 - Item has owner (`uid`) + visibility (`perm`)
 - `/upload` requires auth
 - `uid=0` superuser convention continues until user table exists
+
+### Styling Refinement Pass
+
+- Success state redesign: replace full-width banner with calm inline
+  state near the reference; small label with success hue on text/border
+  only; primary action is copy reference; no colored background fill
+- Focus indication primitive: consistent focus style (thick outline or
+  inset border) that works in grayscale; color is additive only, not
+  load-bearing; applies globally to all interactive elements
+- Spacing token cleanup: define a single vertical rhythm scale
+  (e.g. 0.5/1/1.5/2rem steps); replace ad-hoc micro-gaps throughout;
+  audit all padding/margin values for consistency
+
+>**NOTE:** Shortcode truncation: deferred;
+>references are primary objects so hiding characters is risky;
+>if overflow occurs in practice, prefer overflow-wrap:
+>anywhere over ellipsis; JS prefix+suffix logic is out of scope pre-MVP
 
 ### Global Chrome & Layout Realignment (nav / main / footer / base.html)
 

--- a/doc/planning/unplanned.md
+++ b/doc/planning/unplanned.md
@@ -78,6 +78,18 @@ repo/
 Factory function selects implementation based on config.
 Orchestrator depends on Protocol, concrete impl injected at startup.
 
+## Visual and presentation layer
+
+- /render endpoint: clean presentation view for payload content;
+  minimal UI; optimized for reading; resolves tension between
+  record inspection (/info) and content viewing (/raw stays literal)
+- Success state redesign: move from full-width banner to calm inline
+  state near reference; success hue on text/border only
+- Focus indication primitive: consistent grayscale-first focus style
+  globally across all interactive elements
+- Spacing token cleanup: single vertical rhythm scale; audit all
+  padding/margin values
+
 ## Future Considerations (Post–v1.0)
 
 The following features are not required for v1.0,

--- a/src/depo/static/css/depo.css
+++ b/src/depo/static/css/depo.css
@@ -276,3 +276,36 @@ footer.site-footer .titlebar-inner {
   font-family: var(--depo-font-mono);
   color: var(--pico-primary);
 }
+
+dl.meta {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 0.25rem 1rem;
+  margin: 0.5rem 0;
+}
+dl.meta dt {
+  color: var(--depo-secondary);
+  font-family: var(--depo-font-mono);
+  font-size: var(--depo-size-meta);
+  font-weight: var(--depo-weight-meta);
+}
+dl.meta dd {
+  margin: 0;
+  font-family: var(--depo-font-mono);
+  font-size: var(--depo-size-meta);
+}
+.action-row a {
+  font-family: var(--depo-font-mono);
+  font-size: var(--depo-size-body);
+  color: var(--depo-secondary);
+  text-decoration: none;
+  border: 6px solid var(--depo-border);
+  padding: 0.5rem 1rem;
+  display: inline-block;
+}
+.payload-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin: 0.5rem 0;
+}

--- a/src/depo/static/css/depo.css
+++ b/src/depo/static/css/depo.css
@@ -27,11 +27,12 @@
   --depo-error: rgb(165, 60, 55);
   --depo-secondary: var(--pico-muted-color);
   --depo-focus: var(--pico-primary);
+  --depo-surface: rgb(230, 230, 230);
 
   /* Depo structure */
   --depo-bg: var(--pico-background-color);
   --depo-text: var(--pico-color);
-  --depo-border: rgb(200, 200, 200);
+  --depo-border: rgb(175, 175, 175);
 
 
   /* Typography */
@@ -87,13 +88,13 @@
 body {
   display: flex;
   flex-direction: column;
+  background: var(--depo-surface);
   min-height: 100vh;
 }
 main {
   flex: 1;
   position: relative;
   z-index: 0;
-  background: rgb(230, 230, 230);
   padding: 2rem 1rem;
   max-width: var(--depo-measure);
   margin: 0 auto;
@@ -181,6 +182,7 @@ input, select, textarea {
 /* Custom element classes */
 .titlebar {
   display: flex;
+  background: var(--depo-surface);
   height: 4rem;                 /* fixed bar height; label stretches to fill */
   overflow: hidden;             /* clip label if it overflows bar bounds */
   border-bottom: 2px solid var(--depo-border);
@@ -188,8 +190,6 @@ input, select, textarea {
 .titlebar-label {
   display: flex;
   align-items: center;          /* vertically center text within stretched label */
-  background: rgb(230,230,230); /* matches stripe ground color for seamless punchout */
-  padding: 0 0.5rem;            /* horizontal breathing room around text */
   text-decoration: none;           /* remove default link underline */
 }
 .titlebar-inner {
@@ -206,6 +206,9 @@ footer.site-footer {
   border-top: 2px solid var(--depo-border);
   padding: 1rem 0;
   text-align: center;
+}
+footer.site-footer .titlebar-inner {
+  height: auto;
 }
 
 .window {

--- a/src/depo/static/css/depo.css
+++ b/src/depo/static/css/depo.css
@@ -42,6 +42,9 @@
   --depo-weight-heading: bold;
   --depo-weight-meta: 600;
 
+  /* Spacing */
+  --depo-measure: 48rem;
+
  /* Dither pattern utility classes
  *
  * Apply to any element for a tiled bitmap fill.
@@ -91,6 +94,8 @@ main {
   z-index: 0;
   background: rgb(230, 230, 230);
   padding: 2rem 1rem;
+  max-width: var(--depo-measure);
+  margin: 0 auto;
 }
 
 
@@ -150,12 +155,10 @@ input, select, textarea {
  *   z-index: -1          → sits behind parent content (works because
  *                          parent has z-index: 0 stacking context)
  */
-.shadow-sm,
-.shadow-md {
+.shadow-sm {
   position: relative;
 }
-.shadow-sm::after,
-.shadow-md::after {
+.shadow-sm::after {
   content: '';
   position: absolute;
   width: 100%;
@@ -168,27 +171,16 @@ input, select, textarea {
   image-rendering: pixelated;
   border: 2px solid var(--depo-border);
   z-index: -1;
-}
-.shadow-sm::after {
-  top:  12px;
-  left: 12px;
-}
-.shadow-md::after {
-  top: 20px;
-  left: 20px;
+  top:  4px;
+  left: 4px;
 }
 
 /* Custom element classes */
 .titlebar {
   display: flex;
-  justify-content: flex-start;  /* wordmark left, future nav items follow */
-  align-items: stretch;         /* children fill full bar height */
   height: 4rem;                 /* fixed bar height; label stretches to fill */
-  padding: 0.44rem 1rem 0.20rem;  /* top right bottom gaps between label and backing nav*/
   overflow: hidden;             /* clip label if it overflows bar bounds */
-  background: var(--depo-dither-hstripe) repeat;
-  background-size: 4px 4px;    /* stripe thickness; larger = chunkier lines */
-  image-rendering: pixelated;  /* crisp 1-bit stripes at all DPI */
+  border-bottom: 2px solid var(--depo-border);
 }
 .titlebar-label {
   display: flex;
@@ -197,25 +189,27 @@ input, select, textarea {
   padding: 0 0.5rem;            /* horizontal breathing room around text */
   text-decoration: none;           /* remove default link underline */
 }
+.titlebar-inner {
+  max-width: var(--depo-measure);
+  width: 100%;
+  margin: 0 auto;
+  padding: 0 1rem;
+  display: flex;
+  align-items: center;
+  height: 100%;
+}
 
 footer.site-footer {
-  background: rgb(200, 200, 200);
+  border-top: 2px solid var(--depo-border);
   padding: 1rem 0;
   text-align: center;
-  background-size: 8px 8px;
-  image-rendering: pixelated;
-}
-.footer .meta {
-  display: inline-block;
-  background: rgb(230,230,230);
-  padding: 0.25rem 0.75rem;
 }
 
 .window {
   position: relative;
   border: 2px solid var(--depo-border);
   padding: 1rem;
-  margin: 1.5rem;
+  margin: 0;
   background: var(--depo-bg);
 }
 .window-controls {

--- a/src/depo/static/css/depo.css
+++ b/src/depo/static/css/depo.css
@@ -39,8 +39,9 @@
   --depo-size-heading: 1.5rem;
   --depo-size-body: 1rem;
   --depo-size-meta: 0.8125rem;
-  --depo-weight-heading: bold;
+  --depo-size-code: 1.1rem;
   --depo-weight-meta: 600;
+  --depo-weight-heading: bold;
 
   /* Spacing */
   --depo-measure: 48rem;
@@ -114,6 +115,8 @@ h3, h4, h5, h6 {
 /* Typography — shortcodes and references */
 .shortcode {
   font-family: var(--depo-font-mono);
+  font-size: var(--depo-size-code);
+  letter-spacing: 0.02em;
   font-weight: bold;
 }
 
@@ -217,4 +220,56 @@ footer.site-footer {
   gap: 0.5rem;
   align-items: center;
   margin-top: 0.5rem;
+}
+.window--error {
+  border-color: var(--depo-error);
+  border-left-width: 4px;
+}
+
+.action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+  margin: 0.5rem 0;
+}
+
+.payload {
+  padding: 1rem 0;
+}
+.payload--text {
+  font-family: var(--depo-font-mono);
+  white-space: pre-wrap;
+  font-size: var(--depo-size-body);
+}
+.payload--pic {
+  display: flex;
+  justify-content: center;
+}
+.payload--link {
+  font-family: var(--depo-font-mono);
+  font-size: var(--depo-size-heading);
+}
+
+.divider {
+  border: none;
+  border-top: 2px solid var(--depo-border);
+  margin: 1rem 0;
+}
+
+.attachment-card {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border: 1px solid var(--depo-border);
+}
+
+.file-input-label {
+  display: inline-block;
+  cursor: pointer;
+  padding: 0.5rem 1rem;
+  border: 2px solid var(--pico-primary);
+  font-family: var(--depo-font-mono);
+  color: var(--pico-primary);
 }

--- a/src/depo/templates/info/page.html
+++ b/src/depo/templates/info/page.html
@@ -2,7 +2,7 @@
 {% block content %}
 <!-- BEGIN: info/page.html#content -->
 <!-- EXTENDS: base.html -->
-<article class="window shadow-md">
+<article class="window">
   <h2 class="shortcode">{{ item.code | upper }}</h2>
   <div class="action-row" role="toolbar">
     {% block copy_content %}<button disabled>Copy Content</button>{% endblock %}

--- a/src/depo/templates/info/page.html
+++ b/src/depo/templates/info/page.html
@@ -5,21 +5,21 @@
 <article class="window">
   <h2 class="shortcode">{{ item.code | upper }}</h2>
   <div class="action-row" role="toolbar">
-    {% block copy_content %}<button disabled>Copy Content</button>{% endblock %}
     {% block copy_link %}<button class="secondary" disabled>Copy Link</button>{% endblock %}
-    <button class="outline" data-copy="{{ item.code | upper }}">Copy Code</button>
     <a href="/{{ item.code }}/raw">View Raw</a>
-    <a href="#metadata">Facts</a>
   </div>
-  <div class="payload {% block payload_class %}{% endblock %}" id="payload">
-    {% block payload %}
-    {% endblock %}
-  </div>
-  <hr class="divider">
-  <dl class="meta" id="metadata">
+  <dl class="meta">
     {% block metadata %}
     {% endblock %}
   </dl>
+  <hr class="divider">
+  <div class="payload-actions">
+    {% block copy_content %}<button disabled>Copy Content</button>{% endblock %}
+  </div>
+  <div class="payload {% block payload_class %}{% endblock %}">
+    {% block payload %}
+    {% endblock %}
+  </div>
 </article>
 <!-- END: info/page.html#content -->
 {% endblock %}

--- a/src/depo/templates/partials/foot.html
+++ b/src/depo/templates/partials/foot.html
@@ -1,10 +1,12 @@
 <!-- BEGIN: partials/foot.html -->
 <footer class="site-footer">
-  <p class="meta">
-    <a href="https://github.com/marcus-grant/depo">Depo</a> ·
-    <a href="https://github.com/marcus-grant">Marcus Grant</a> ·
-    2026 · Apache License 2.0 ·
-    <a href="https://github.com/marcus-grant/depo/issues">report issues</a>
-  </p>
+  <div class="titlebar-inner">
+    <p class="meta">
+      <a href="https://github.com/marcus-grant/depo">Depo</a> ·
+      <a href="https://github.com/marcus-grant">Marcus Grant</a> ·
+      2026 · Apache License 2.0 ·
+      <a href="https://github.com/marcus-grant/depo/issues">report issues</a>
+    </p>
+  </div>
 </footer>
 <!-- END: partials/foot.html -->

--- a/src/depo/templates/partials/nav.html
+++ b/src/depo/templates/partials/nav.html
@@ -1,5 +1,7 @@
 <!-- BEGIN: partials/nav.html -->
-<nav class="tui-border titlebar">
-  <a class="titlebar-label" href="/"><strong>Depo</strong></a>
+<nav class="titlebar">
+  <div class="titlebar-inner">
+    <a class="titlebar-label" href="/"><strong>Depo</strong></a>
+  </div>
 </nav>
 <!-- END: partials/nav.html -->

--- a/src/depo/templates/upload/page.html
+++ b/src/depo/templates/upload/page.html
@@ -2,7 +2,7 @@
 {% block content %}
 <!-- BEGIN: upload/page.html#content -->
 <!-- EXTENDS: base.html -->
-<div class="window shadow-md">
+<div class="window">
   <form method="post" action="/upload" hx-post="/upload" hx-target="#result" hx-swap="innerHTML">
     <input type="file" name="file" id="file-input" hidden>
     <label for="file-input" class="file-input-label">Add File</label>

--- a/tests/web/test_info_templates.py
+++ b/tests/web/test_info_templates.py
@@ -62,27 +62,17 @@ class TestInfoStructure:
         """Has .action-row after shortcode."""
         assert self.select("article.window > .shortcode + .action-row") is not None
 
-    def test_payload_after_action(self):
-        """Has #payload container after action row."""
-        assert self.select("article.window > .action-row + #payload") is not None
+    def test_metadata_after_action(self):
+        """Has dl.meta after action row."""
+        assert self.select(".action-row + dl.meta") is not None
 
-    def test_payload_meta_divider(self):
-        """Has divider between payload and metadata."""
-        assert self.select("#payload + hr.divider") is not None
+    def test_divider_after_metadata(self):
+        """Has divider after metadata."""
+        assert self.select("dl.meta + hr.divider") is not None
 
-    def test_metadata_after_divider(self):
-        """Has #metadata dl after divider."""
-        assert self.select("hr.divider + dl#metadata") is not None
-
-    def test_action_copy_shortcode(self):
-        """Copy shortcode button carries code value for clipboard."""
-        btn = self.select(".action-row button.outline[data-copy]")
-        assert btn is not None
-        assert btn.get("data-copy") != ""
-
-    def test_action_facts_jump(self):
-        """Facts anchor links to metadata section."""
-        assert self.select(".action-row a[href='#metadata']") is not None
+    def test_payload_after_divider(self):
+        """Has .payload-actions after divider."""
+        assert self.select("hr.divider + .payload-actions") is not None
 
     def test_clipboard_script(self):
         """Clipboard handler script is present."""
@@ -92,6 +82,10 @@ class TestInfoStructure:
         """Action row contains link to raw view."""
         link = self.select(".action-row a[href*='/raw']")
         assert link is not None
+
+    def test_payload_actions_before_payload(self):
+        """Has .payload-actions div directly before .payload."""
+        assert self.select(".payload-actions + .payload") is not None
 
 
 class TestInfoLink:
@@ -103,22 +97,23 @@ class TestInfoLink:
 
     def test_url_in_payload(self):
         """Renders URL in payload section."""
-        assert self.select("#payload a") is not None
-        assert self.select("#payload a").text == "https://example.com"  # type: ignore
+        assert self.select(".payload a") is not None
+        assert self.select(".payload a").text == "https://example.com"  # type: ignore
 
     def test_upload_at_in_metadata(self):
         """Renders upload timestamp in metadata."""
-        dl = self.select("dl#metadata")
+        dl = self.select("dl.meta")
         assert dl is not None
         assert any(w in dl.text.lower() for w in ("upload", "creat", "date", "time"))
 
     def test_payload_modifier(self):
         """Payload has type-specific class."""
-        assert self.select("#payload.payload--link") is not None
+        assert self.select(".payload.payload--link") is not None
 
     def test_copy_content_button(self):
         """Copy content button carries origin URL for clipboard."""
-        btn = self.select(".action-row button[data-copy]:not(.secondary):not(.outline)")
+        sel = ".payload-actions button[data-copy]:not(.secondary):not(.outline)"
+        btn = self.select(sel)
         assert btn is not None
         assert btn["data-copy"] == "https://example.com"
 
@@ -138,13 +133,13 @@ class TestInfoText:
 
     def test_content_in_pre_code_payload(self):
         """Renders text content inside <pre><code> in payload."""
-        el = self.select("#payload pre code")
+        el = self.select(".payload pre code")
         assert el is not None
         assert _TXT_DATA in el.text
 
     def test_metadata_fields_present(self):
         """Renders format, size, upload timestamp in metadata."""
-        dl = self.select("dl#metadata")
+        dl = self.select("dl.meta")
         assert dl is not None
         text = dl.text.lower()
         assert any(w in text for w in ("format", "type"))
@@ -153,11 +148,11 @@ class TestInfoText:
 
     def test_payload_modifier(self):
         """Payload has type-specific class."""
-        assert self.select("#payload.payload--text") is not None
+        assert self.select(".payload.payload--text") is not None
 
     def test_copy_content_button(self):
         """Copy content button carries extensioned fetch URL."""
-        btn = self.select(".action-row button[data-copy-url]")
+        btn = self.select(".payload-actions button[data-copy-url]")
         assert btn is not None
         assert btn["data-copy-url"].endswith(".txt")  # type: ignore
 
@@ -177,14 +172,14 @@ class TestInfoPic:
 
     def test_img_tag_in_payload(self):
         """Renders <img> tag in payload with correct src."""
-        img = self.select("#payload img")
+        img = self.select(".payload img")
         assert img is not None
         assert img.get("src", "") != ""
         assert img["src"].endswith(".jpg")  # type: ignore
 
     def test_metadata_fields_present(self):
         """Renders format, size, dimensions, upload timestamp in metadata."""
-        dl = self.select("dl#metadata")
+        dl = self.select("dl.meta")
         assert dl is not None
         text = dl.text.lower()
         assert any(w in text for w in ("format", "type"))
@@ -194,11 +189,11 @@ class TestInfoPic:
 
     def test_payload_modifier(self):
         """Payload has type-specific class."""
-        assert self.select("#payload.payload--pic") is not None
+        assert self.select(".payload.payload--pic") is not None
 
     def test_copy_content_button(self):
         """Copy content button carries extensioned fetch URL."""
-        btn = self.select(".action-row button[data-copy-url]")
+        btn = self.select(".payload-actions button[data-copy-url]")
         assert btn is not None
         assert btn["data-copy-url"].endswith(".jpg")  # type: ignore
 


### PR DESCRIPTION
- Global chrome realignment: titlebar border-only, surface tokens,
  footer cleanup, window flush in main, shadow-md removed
- CSS rules for unstyled markup classes: action-row, payload/*,
  divider, attachment-card, file-input-label, window--error
- Info page restructure: metadata before payload, copy_content
  moved to payload-actions, Copy Code and Facts link removed
- dl.meta grid layout for label/value metadata display
- payload-actions class for payload-level actions
- main_class block in base.html; main--wide variant for upload page
- article.window Pico override to reset card styles
- Design language and planning docs updated
