### PR TITLE
Ref: Unexpected-error boundary

### DIFF
--- a/doc/design/errors.md
+++ b/doc/design/errors.md
@@ -58,49 +58,70 @@ so a new error added without a severity decision fails the suite.
 
 ## Response builders
 
-`depo.web.error` provides three builders for route handlers:
+`depo.web.error` provides three builders.
+Each returns a finished `Response`,
+so route handlers and the boundary pick a builder rather than
+assemble responses themselves:
 
 - `api_error(e: DepoError)`: returns `PlainTextResponse(str(e), status_code=e.status)`
-- `htmx_error(e: DepoError, role: str = "alert")`: returns kwargs dict for
-  `TemplateResponse` handlers; role used as CSS modifier and ARIA attribute
+- `htmx_error(req, e: DepoError, role: str = "alert")`: returns the
+  `errors/partial.html` `TemplateResponse` hardcoded at `status_code=200`,
+  the HTMX contract. `role` is used as CSS modifier and ARIA attribute
 - `browser_error(req, e: DepoError)`: returns full-page `TemplateResponse`
-  using `errors/page.html`; renders debug block for 5xx errors
+  using `errors/page.html` at `e.status`; renders debug block for 5xx errors
 
 ## Route handler pattern
 
-API handlers catch `DepoError` broadly:
+API handlers catch `DepoError` broadly and return a builder:
 
 ```python
 except DepoError as e:
     return api_error(e)
 ```
 
-HTMX handlers always return 200. Error info lives in the partial body:
+HTMX handlers always return 200, with error info in the partial body:
 
 ```python
 except DepoError as e:
-    kw |= htmx_error(e)
-except Exception as e:
-    kw |= htmx_error(UnknownServerError(e))
+    return htmx_error(request, e)
 ```
+
+Routes catch only `DepoError`.
+Non-`DepoError` exceptions are left to escape to the app-level boundary,
+which removes the need for per-route bare `except Exception` guards.
+
+## Unexpected-error boundary
+
+`unhandled(request, exc)` in `depo.web.error` is registered on the app via
+`add_exception_handler(Exception, unhandled)` in `app_factory`.
+It catches any non-DepoError that escapes a route,
+wraps it in `UnknownServerError`, negotiates surface
+(`is_htmx` to `htmx_error`, `wants_html` to `browser_error`, otherwise `api_error`),
+and delegates.
+It does not log: the builder it delegates to is the logging seam.
 
 ## Logging
 
 The three response builders are the single logging seam.
-Each calls a module-level `_log(e)` first,
-emitting one record on the `depo` logger at `e.severity` with `e.message`,
+Each calls `log_error(e)` first, emitting one record at `e.severity` with `e.message`,
 attaching `exc_info` when `e.exception` is set.
+The helper logs on `getLogger(__name__)`,
+a child of the `depo` logger, so there is no stored module logger to keep in sync.
 Routes do not log; building the response logs.
-
+The boundary handler does not log, since it delegates to a builder.
 `configure_logging(level)` in `web/app.py` sets the `depo` logger level and
-attaches a text handler.
-`app_factory` calls it first,
+attaches a text handler. `app_factory` calls it first,
 driven by the `log_level` config field (see [cli](../module/cli.md)).
 Propagation stays on so test capture and parent handlers still see records.
 
 ## Deferred
 
 Browser error templates for the non-404 4xx codes (400, 409, 413, 422)
+
+The non-HTMX form fallback in `hx_upload`'s dispatcher has no `except DepoError`.
+Expected domain errors on that path currently reach the boundary and
+badly classify as 500 instead of their true 4xx status.
+Needs first-class error handling, tracked in planning.
 
 Remaining error-handling work is tracked in planning:
 structured logging observability in `v0.2`,

--- a/doc/module/web.md
+++ b/doc/module/web.md
@@ -16,7 +16,10 @@ configure_logging(level: str) -> None
 
 `app_factory` creates the FastAPI instance, initializes DB and storage,
 wires repo/storage/orchestrator onto `app.state`.
-Includes route handlers via`APIRouter`.
+Includes route handlers via `APIRouter`.
+Registers the `unhandled` boundary via
+`add_exception_handler(Exception, ...)` to
+catch non-DepoError exceptions that escape routes.
 Mounts static files from `src/depo/static/`.
 SQLite uses `check_same_thread=False` for async handler compatibility.
 
@@ -83,7 +86,7 @@ Algebraic union, each variant corresponds to an upload path.
 - `UploadRawBodyParams` - payload_bytes, declared_mime
 - `UploadFormParams` - payload_bytes, declared_mime, requested_format
 
-#### Functions
+#### upload.py - functions
 
 - `_parse_upload(file, url, request)`:
   - extract orchestrator kwargs from API request
@@ -181,18 +184,25 @@ All exceptions carry
 `status`, `message`, `ctx`, `severity`, and `exception` fields.
 Route handlers catch `DepoError` broadly using `e.status` for response codes.
 
-Response builders live in `depo.web.error`:
+Response builders live in `depo.web.error`. Each returns a finished
+`Response`:
 
 - `api_error(e)`
-  - PlainTextResponse with `e.status`
-- `htmx_error(e, role="alert")`
-  - __kwargs__ dict for `TemplateResponse` handlers;
+  - `PlainTextResponse` with `e.status`
+- `htmx_error(req, e, role="alert")`
+  - `errors/partial.html` `TemplateResponse` hardcoded at `status_code=200`
   - role as CSS modifier and ARIA attribute
 - `browser_error(req, e)`
-  - full-page `TemplateResponse` using `errors/page.html`
+  - full-page `TemplateResponse` using `errors/page.html` at `e.status`
 
 These builders are also the single logging seam:
-each emits one record on the `depo` logger at `e.severity`,
+each calls `log_error(e)`, emitting one record at `e.severity`,
 attaching `exc_info` when `e.exception` is set.
+
+Non-DepoError exceptions that escape a route are caught by
+the app-level boundary `unhandled`, registered in `app_factory`.
+It wraps the exception in `UnknownServerError`, negotiates surface,
+and delegates to a builder.
+It does not log; the builder does.
 
 See [errors.md](../design/errors.md) for the full hierarchy and patterns.

--- a/doc/planning/mvp.md
+++ b/doc/planning/mvp.md
@@ -30,90 +30,6 @@ service, repo, and storage. Dedupe by content hash.
 
 Ordered by dependency. Each heading is roughly one PR.
 
-### Unexpected-error boundary (Branch: `ref/error-boundary`)
-
-*Problem: non-DepoError exceptions slip past the per-route `except DepoError`
-catches and reach FastAPI's default 500 unlogged, and `hx_upload` guards its
-own HTMX case with a bare except. Centralize unexpected errors in one
-app-level handler that wraps, negotiates surface, and delegates to a builder.
-The builders already log (PR 1), so the handler must not log again. Depends on
-`ft/error-logging`.*
-
-#### Setup and gating test
-
-- [ ] `git checkout -b ref/error-boundary`
-- [ ] `tests/web/test_errors.py`: skipped integration test. Monkeypatch a
-      selector call to raise `OSError`, hit a shortcode GET, assert a logged
-      controlled 500; repeat with `HX-Request` and assert 200 plus the error
-      partial. Needs the no-reraise client. Mark
-      `@pytest.mark.skip("boundary not implemented")`.
-- [ ] `uv run ruff check && uv run pytest`
-- [ ] Commit: `Tst: Add skipped boundary integration test`
-
-**Carryover from ft/error-logging** (`web/error.py`, `util/errors.py`, `tests/cli/test_config.py`)
-
-- [ ] Extract `_log(e)` helper in `web/error.py`: rename the module logger to
-      `_logger`, add `_log(e)` emitting at `e.severity` with
-      `exc_info=e.exception`, replace the inline calls in all three builders
-      with `_log(e)`. Covered by existing builder-logging tests.
-- [ ] Annotate `severity: Severity` on `DepoError` to match the slot intent.
-- [ ] Add a TOML resolution test for `log_level` in `test_config.py`.
-- [ ] `uv run ruff check && uv run pytest`
-- [ ] Commit: `Ref: Extract _log helper, close ft/error-logging gaps`
-
-#### TDD implementation
-
-**Uniform builder return** (`tests/web/test_error_responses.py`)
-
-- [ ] Change `htmx_error` to `htmx_error(req, e, role="alert") -> Response`,
-      returning the `errors/partial.html` TemplateResponse hardcoded at
-      `status_code=200` (the HTMX contract, unlike `browser_error` which uses
-      `e.status`).
-- [ ] Update `hx_upload`: error branch becomes `return htmx_error(request, e)`,
-      success path returns its TemplateResponse directly, the `kw` merge goes
-      away. Leave the `except Exception` branch for now as
-      `return htmx_error(request, UnknownServerError(e))`.
-- [ ] Rewrite the 4 `TestHtmxError` tests to assert on the Response (status
-      200, partial marker, error in context) instead of dict keys.
-- [ ] `uv run ruff check && uv run pytest`
-- [ ] Commit: `Ref: Make htmx_error return a Response`
-
-**Boundary handler** (`tests/web/test_errors.py`, fixture in `tests/fixtures/__init__.py`)
-
-- [ ] Add `unhandled(request, exc) -> Response` to `web/error.py`: wrap in
-      `UnknownServerError(exc)`, then `is_htmx` -> `htmx_error`, `wants_html`
-      -> `browser_error`, else `api_error`. No log call here; the builders log.
-- [ ] Register in `app_factory`: `app.add_exception_handler(Exception, unhandled)`.
-- [ ] Add a `TestClient(client.app, raise_server_exceptions=False)` fixture
-      mirroring `t_client`, so the handler's response is observable.
-- [ ] Tests: non-DepoError through a shortcode GET gives a logged controlled
-      500 (api and browser surfaces); with `HX-Request`, 200 plus partial.
-      Confirm `_500_response()` in `test_errors.py:52` still holds; adjust if
-      it leaned on the default 500.
-- [ ] `uv run ruff check && uv run pytest`
-- [ ] Commit: `Ft: Add app-level boundary handler for unexpected errors`
-
-**Thin hx_upload** (`tests/web/routes/test_upload.py`)
-
-- [ ] Remove `hx_upload`'s `except Exception`; unexpected upload errors now
-      bubble to the boundary.
-- [ ] Test: inject a non-DepoError into the upload path through the no-reraise
-      client, assert 200 plus partial via the boundary.
-- [ ] `uv run ruff check && uv run pytest`
-- [ ] Commit: `Ref: Remove hx_upload bare except, defer to boundary`
-
-#### Integration and documentation
-
-- [ ] Remove the skip from the gating test, verify it passes.
-- [ ] Update `doc/design/errors.md` and `doc/module/web.md` (boundary handler,
-      uniform builders, hx_upload thinning), kept linked from their READMEs.
-- [ ] `uv run ruff check && uv run pytest`
-- [ ] Commit: `Doc: Document unexpected-error boundary`
-
-#### PR
-
-- [ ] `gh pr create --title "Ref: Unexpected-error boundary" --body "..."`
-
 ### Config and limits
 
 - Raise default upload limit to 64MiB (`max_size_bytes` = 67_108_864);
@@ -126,6 +42,27 @@ The builders already log (PR 1), so the handler must not log again. Depends on
   - Use `isinstance` dispatch.
   - Reduces null coalescing throughout ingest pipeline.
   - Related to temp file streaming and async pipeline work.
+
+### Non-HTMX form fallback error handling (needs planning)
+
+Problem: the `application/x-www-form-urlencoded` fallback branch in the
+upload dispatcher (`web/routes/upload.py`) runs `_parse_form_upload` and
+`orch.ingest` with no `except DepoError`. Expected domain errors (empty,
+oversized, bad format) on a non-HTMX form POST escape to the app-level
+boundary, which wraps them as `UnknownServerError` and renders a 500. This
+mislabels ordinary 4xx domain errors as server errors and discards their
+real status and message.
+
+This was assumed closed by the `ref/error-boundary` boundary handler. It is
+not: the boundary is for unexpected errors and must not be the catch path
+for expected ones. The fix is entangled with the fallback's success shape
+(currently a 303 redirect, no error render of its own), so the surface and
+flow need a design decision, not a patch.
+
+To plan: what the non-HTMX form path renders on a DepoError (full-page
+browser_error, redirect-with-flash, or other), whether the success redirect
+stays, and how this interacts with the deferred non-404 4xx browser
+templates. Plan alongside request access logging.
 
 ### Auth
 

--- a/src/depo/util/errors.py
+++ b/src/depo/util/errors.py
@@ -28,8 +28,7 @@ class Severity(IntEnum):
 class DepoError(Exception):
     """Root exception for all depo errors."""
 
-    severity = Severity.ERROR
-    exception = None
+    severity: Severity = Severity.ERROR
     status = 500
     message = "Unexpected error occurred, report to https://github.com/marcus-grant/depo/issues"
     exception: Exception | None = None

--- a/src/depo/web/app.py
+++ b/src/depo/web/app.py
@@ -55,6 +55,12 @@ def app_factory(config: DepoConfig) -> FastAPI:
     # Store the router for FastAPI
     app.include_router(router)
 
+    # App-level boundary: catch non-DepoError exceptions that escape
+    # per-route handlers, negotiate surface, delegate to a builder.
+    from depo.web.error import unhandled
+
+    app.add_exception_handler(Exception, unhandled)
+
     # Mount static assets directory for frontend - must come AFTER routes
     static_dir = Path(__file__).parent.parent / "static"
     app.mount("/static", StaticFiles(directory=static_dir), name="static")

--- a/src/depo/web/error.py
+++ b/src/depo/web/error.py
@@ -22,6 +22,12 @@ def log_error(e: DepoError) -> None:
     logging.getLogger(__name__).log(e.severity, e.message, exc_info=e.exception)
 
 
+def api_error(err: DepoError) -> PlainTextResponse:
+    """Return a PlainTextResponse for API clients."""
+    log_error(err)
+    return PlainTextResponse(str(err), status_code=err.status)
+
+
 def browser_error(req: Request, err: DepoError) -> Response:
     """Return a full-page error TemplateResponse for browser clients."""
     log_error(err)
@@ -33,13 +39,12 @@ def browser_error(req: Request, err: DepoError) -> Response:
     )
 
 
-def api_error(err: DepoError) -> PlainTextResponse:
-    """Return a PlainTextResponse for API clients."""
+def htmx_error(req: Request, err: DepoError, role: str = "alert") -> Response:
+    """Return an HTMX partial TemplateResponse, always at HTTP 200."""
     log_error(err)
-    return PlainTextResponse(str(err), status_code=err.status)
-
-
-def htmx_error(err: DepoError, role: str = "alert") -> dict:
-    """Return kwargs dict for HTMX partial TemplateResponse error renders."""
-    log_error(err)
-    return {"name": "errors/partial.html", "context": {"error": err, "role": role}}
+    return _get().TemplateResponse(
+        request=req,
+        name="errors/partial.html",
+        status_code=200,
+        context={"error": err, "role": role},
+    )

--- a/src/depo/web/error.py
+++ b/src/depo/web/error.py
@@ -16,12 +16,15 @@ from depo.web.templates import get_templates as _get
 
 _ISSUES_URL = "https://github.com/marcus-grant/depo/issues"
 
-_log = logging.getLogger("depo.web.error")
+
+def log_error(e: DepoError) -> None:
+    """Emit one record on the module logger at the error's severity."""
+    logging.getLogger(__name__).log(e.severity, e.message, exc_info=e.exception)
 
 
 def browser_error(req: Request, err: DepoError) -> Response:
     """Return a full-page error TemplateResponse for browser clients."""
-    _log.log(err.severity, err.message, exc_info=err.exception)
+    log_error(err)
     return _get().TemplateResponse(
         request=req,
         name="errors/page.html",
@@ -32,11 +35,11 @@ def browser_error(req: Request, err: DepoError) -> Response:
 
 def api_error(err: DepoError) -> PlainTextResponse:
     """Return a PlainTextResponse for API clients."""
-    _log.log(err.severity, err.message, exc_info=err.exception)
+    log_error(err)
     return PlainTextResponse(str(err), status_code=err.status)
 
 
 def htmx_error(err: DepoError, role: str = "alert") -> dict:
     """Return kwargs dict for HTMX partial TemplateResponse error renders."""
-    _log.log(err.severity, err.message, exc_info=err.exception)
+    log_error(err)
     return {"name": "errors/partial.html", "context": {"error": err, "role": role}}

--- a/src/depo/web/error.py
+++ b/src/depo/web/error.py
@@ -11,8 +11,10 @@ import logging
 from fastapi import Request
 from starlette.responses import PlainTextResponse, Response
 
-from depo.util.errors import DepoError
+from depo.util.errors import DepoError, UnknownServerError
+from depo.web.negotiate import wants_html
 from depo.web.templates import get_templates as _get
+from depo.web.templates import is_htmx
 
 _ISSUES_URL = "https://github.com/marcus-grant/depo/issues"
 
@@ -20,6 +22,20 @@ _ISSUES_URL = "https://github.com/marcus-grant/depo/issues"
 def log_error(e: DepoError) -> None:
     """Emit one record on the module logger at the error's severity."""
     logging.getLogger(__name__).log(e.severity, e.message, exc_info=e.exception)
+
+
+def unhandled(request: Request, exc: Exception) -> Response:
+    """App-level boundary for non-DepoError exceptions.
+
+    Wraps the exception as UnknownServerError and delegates to the
+    surface-appropriate builder. Does not log: the builders log.
+    """
+    err = UnknownServerError(exc)
+    if is_htmx(request):
+        return htmx_error(request, err)
+    if wants_html(request):
+        return browser_error(request, err)
+    return api_error(err)
 
 
 def api_error(err: DepoError) -> PlainTextResponse:

--- a/src/depo/web/routes/upload.py
+++ b/src/depo/web/routes/upload.py
@@ -13,7 +13,7 @@ License: Apache-2.0
 from typing import TypedDict
 
 from fastapi import APIRouter, Depends, Query, Request, Response, UploadFile
-from fastapi.responses import HTMLResponse, PlainTextResponse, RedirectResponse
+from fastapi.responses import PlainTextResponse, RedirectResponse
 from starlette.datastructures import UploadFile as StarletteUploadFile
 
 from depo.model.enums import ContentFormat
@@ -64,18 +64,21 @@ async def upload(
 async def hx_upload(
     request: Request,
     orch: IngestOrchestrator = Depends(get_orchestrator),
-) -> HTMLResponse:
+) -> Response:
     """Browser form upload: textarea content + format override."""
-    kw = {"request": request, "name": "partials/success.html", "status_code": 200}
     try:
         params = await _parse_form_upload(request)
         result = orch.ingest(**dict(params))  # type: ignore[arg-type]
-        kw["context"] = {"code": result.item.code, "created": result.created}
+        return get_templates().TemplateResponse(
+            request=request,
+            name="partials/success.html",
+            status_code=200,
+            context={"code": result.item.code, "created": result.created},
+        )
     except DepoError as e:
-        kw |= htmx_error(e)
+        return htmx_error(request, e)
     except Exception as e:
-        kw |= htmx_error(UnknownServerError(e))
-    return get_templates().TemplateResponse(**kw)
+        return htmx_error(request, UnknownServerError(e))
 
 
 async def api_upload(

--- a/src/depo/web/routes/upload.py
+++ b/src/depo/web/routes/upload.py
@@ -23,7 +23,6 @@ from depo.util.errors import (
     DepoError,
     PayloadEmptyError,
     PayloadSourceError,
-    UnknownServerError,
 )
 from depo.web.deps import get_orchestrator
 from depo.web.error import api_error, htmx_error
@@ -77,8 +76,6 @@ async def hx_upload(
         )
     except DepoError as e:
         return htmx_error(request, e)
-    except Exception as e:
-        return htmx_error(request, UnknownServerError(e))
 
 
 async def api_upload(

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -139,6 +139,14 @@ class TestLoadConfigToml:
         assert cfg.port == 8765
         assert cfg.max_url_len == 2048
 
+    def test_toml_log_level(self, monkeypatch, tmp_path):
+        """log_level resolves from a TOML config file."""
+        _clear_depo_env(monkeypatch)
+        _write_toml(tmp_path / "xdg/depo/config.toml", log_level="DEBUG")
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
+        monkeypatch.chdir(tmp_path)
+        assert load_config().log_level == "DEBUG"
+
 
 class TestLoadConfigEnv:
     """Tests for DEPO_* environment variable overrides."""

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -129,6 +129,20 @@ def t_htmx(tmp_path) -> TestClient:
     return TestClient(client.app, headers={"HX-Request": "true"})
 
 
+@pytest.fixture
+def t_noreraise(tmp_path) -> TestClient:
+    """TestClient that surfaces the app's 500 instead of re-raising.
+
+    Mirrors t_client but with raise_server_exceptions=False, so the
+    app-level boundary handler's response is observable rather than
+    propagated as an exception. Select surface per-request via Accept
+    or HX-Request headers.
+    Depends on pytest builtin fixture: tmp_path for isolated filesystem.
+    """
+    client = make_client(tmp_path)
+    return TestClient(client.app, raise_server_exceptions=False)
+
+
 @dataclass(frozen=True)
 class SeededApp:
     """TestClient bundled with pre-populated items.
@@ -175,15 +189,3 @@ def t_seeded(tmp_path) -> SeededApp:
     store.put(code=item_txt.code, format=item_txt.format, source_bytes=txt_data)
     store.put(code=item_pic.code, format=item_pic.format, source_bytes=pic_data)
     return SeededApp(client, browser, htmx, item_txt, item_pic, item_link)
-
-
-__all__ = [
-    "SeededApp",
-    "t_client",
-    "t_conn",
-    "t_db",
-    "t_orch_env",
-    "t_repo",
-    "t_seeded",
-    "t_store",
-]

--- a/tests/web/test_error_responses.py
+++ b/tests/web/test_error_responses.py
@@ -32,23 +32,30 @@ class TestApiError:
 
 
 class TestHtmxError:
-    """Tests for htmx_error kwargs builder."""
+    """Tests for htmx_error Response builder."""
 
-    def test_returns_error_partial(self):
-        """Returns dict with errors/partial.html template name."""
-        assert htmx_error(_T_DEPO_ERR)["name"] == "errors/partial.html"
+    def test_uses_partial_template(self):
+        """htmx_error always uses errors/partial.html."""
+        req, e = make_request(), _T_DEPO_ERR
+        assert htmx_error(req, e).template.name == "errors/partial.html"  # type: ignore
+
+    def test_status_code_is_200(self):
+        """HTMX contract: status is always 200 regardless of error status."""
+        assert htmx_error(make_request(), _T_DEPO_ERR).status_code == 200
 
     def test_context_contains_error_object(self):
         """Context contains error object, not string."""
-        assert htmx_error(_T_DEPO_ERR)["context"]["error"] is _T_DEPO_ERR
+        req, e = make_request(), _T_DEPO_ERR
+        assert htmx_error(req, e).context["error"] is e  # type: ignore
 
     def test_default_role_is_alert(self):
         """Default role 'alert' passed in context."""
-        assert htmx_error(_T_DEPO_ERR)["context"]["role"] == "alert"
+        assert htmx_error(make_request(), _T_DEPO_ERR).context["role"] == "alert"  # type: ignore
 
     def test_custom_role_in_context(self):
         """Custom role passed through to context."""
-        assert htmx_error(_T_DEPO_ERR, role="status")["context"]["role"] == "status"
+        resp = htmx_error(make_request(), _T_DEPO_ERR, role="status")
+        assert resp.context["role"] == "status"  # type: ignore
 
 
 class TestBrowserError:
@@ -101,7 +108,7 @@ class TestErrorLogging:
         [
             lambda e: api_error(e),
             lambda e: browser_error(make_request(), e),
-            lambda e: htmx_error(e),
+            lambda e: htmx_error(make_request(), e),
         ],
         ids=["api", "browser", "htmx"],
     )

--- a/tests/web/test_error_responses.py
+++ b/tests/web/test_error_responses.py
@@ -12,7 +12,7 @@ import logging
 import pytest
 
 from depo.util.errors import DepoError, NotFoundError
-from depo.web.error import _ISSUES_URL, api_error, browser_error, htmx_error
+from depo.web.error import _ISSUES_URL, api_error, browser_error, htmx_error, log_error
 from tests.factories import make_request
 
 _T_DEPO_ERR = DepoError("something went wrong")
@@ -77,6 +77,24 @@ class TestBrowserError:
 
 class TestErrorLogging:
     """Builders emit one depo log record at the error's severity."""
+
+    def test_log_error_emits_one_record_at_severity(self, caplog):
+        """log_error emits exactly one depo record at the error's severity."""
+        caplog.set_level(logging.DEBUG, logger="depo")
+        log_error(_T_NOTFOUND_ERR)
+        recs = [r for r in caplog.records if r.name.startswith("depo")]
+        assert len(recs) == 1
+        assert recs[0].levelno == logging.INFO
+        assert recs[0].getMessage() == _T_NOTFOUND_ERR.message
+
+    def test_log_error_attaches_exc_info(self, caplog):
+        """log_error attaches exc_info from the error's exception."""
+        caplog.set_level(logging.DEBUG, logger="depo")
+        err = NotFoundError(id="ABC12345")
+        err.exception = ValueError("boom")
+        log_error(err)
+        recs = [r for r in caplog.records if r.name.startswith("depo")]
+        assert recs[0].exc_info is not None
 
     @pytest.mark.parametrize(
         "call",

--- a/tests/web/test_errors.py
+++ b/tests/web/test_errors.py
@@ -96,3 +96,50 @@ class TestHtmxErrorPartial:
         """HTMX error responses always return 200 status."""
         assert self._empty_resp(t_client).status_code == 200
         assert self._oversize_resp(t_client).status_code == 200
+
+
+class TestUnexpectedErrorBoundary:
+    """Non-DepoError exceptions hit the app-level boundary, get wrapped
+    as UnknownServerError, surface-negotiated, and logged once."""
+
+    def _patch_selector_oserror(self, monkeypatch):
+        """Make selector.get_item raise a non-DepoError on any call."""
+        from depo.web.routes import shortcode
+
+        def _boom(*_):
+            raise OSError("disk gone")
+
+        monkeypatch.setattr(shortcode.selector, "get_item", _boom)
+
+    def test_boundary_browser_returns_500_page(self, t_noreraise, monkeypatch):
+        """Browser surface: non-DepoError yields a controlled 500 rendering
+        errors/page.html, not FastAPI's default 500."""
+        self._patch_selector_oserror(monkeypatch)
+        resp = t_noreraise.get("/ABC12345/info", headers={"Accept": "text/html"})
+        assert resp.status_code == 500
+        assert "<!-- BEGIN: errors/page.html" in resp.text
+
+    def test_boundary_api_returns_500(self, t_noreraise, monkeypatch):
+        """API surface: non-DepoError yields a controlled 500 response."""
+        self._patch_selector_oserror(monkeypatch)
+        resp = t_noreraise.get("/ABC12345/info")
+        assert resp.status_code == 500
+
+    def test_boundary_htmx_returns_200_partial(self, t_noreraise, monkeypatch):
+        """HTMX surface: non-DepoError yields 200 plus errors/partial.html,
+        honoring the HTMX contract that errors ride in the body."""
+        self._patch_selector_oserror(monkeypatch)
+        resp = t_noreraise.get("/ABC12345/info", headers=HEADER_HTMX)
+        assert resp.status_code == 200
+        assert "<!-- BEGIN: errors/partial.html" in resp.text
+
+    def test_boundary_logs_once(self, t_noreraise, monkeypatch, caplog):
+        """The boundary logs exactly one depo record: the builders log,
+        the handler must not log again."""
+        import logging
+
+        self._patch_selector_oserror(monkeypatch)
+        caplog.set_level(logging.DEBUG, logger="depo")
+        t_noreraise.get("/ABC12345/info")
+        recs = [r for r in caplog.records if r.name.startswith("depo")]
+        assert len(recs) == 1


### PR DESCRIPTION
Centralizes unexpected-error handling in one app-level boundary.
Non-DepoError exceptions that escape per-route `except DepoError`
catches are now caught by `unhandled`, wrapped as UnknownServerError,
surface-negotiated, and delegated to a builder. Builders are the sole
logging seam; the handler does not log.

Also closes carryover gaps from ft/error-logging: extracts the
log_error helper (logging on getLogger(__name__), no stored module
logger), annotates severity on DepoError, adds log_level TOML
resolution coverage. Unifies the three builders to return a Response,
with htmx_error hardcoded at 200 per the HTMX contract. Thins
hx_upload by removing its bare except, deferring unexpected upload
errors to the boundary.

Notes:
- The skipped gating test from the plan was absorbed into the
  boundary handler's live tests rather than landed as a placeholder.
- hx_upload thinning is refactor-under-green: hx_upload is only
  reached via HTMX, so removing the bare except has no observable
  surface change; existing tests plus the boundary tests guard it.
- Surfaced a real gap, the non-HTMX form fallback misclassifies
  expected 4xx domain errors as 500 via the boundary. Documented and
  filed for a planning session, not fixed here.
