### PR TITLE
Ref: Canonical config

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,7 @@ Start here:
 
 ## Project status
 
-Pre-alpha, parked.
-Bootstrap is complete; the project compiles, the config module
-is implemented and tested, but no daemon behavior has been built
-yet.
-Focus has shifted to the ecosystem pieces that will consume this
-daemon before continuing here.
-See `doc/TODO.md` for the resumption work plan.
+This project is in active development.
 
 - **v0.0.1 (MVP)** focuses on a correct, minimal foundation
 - **v1.0** adds aliases, editing, invitations, and public-sharing readiness

--- a/README.md
+++ b/README.md
@@ -16,7 +16,13 @@ Start here:
 
 ## Project status
 
-This project is in active development.
+Pre-alpha, parked.
+Bootstrap is complete; the project compiles, the config module
+is implemented and tested, but no daemon behavior has been built
+yet.
+Focus has shifted to the ecosystem pieces that will consume this
+daemon before continuing here.
+See `doc/TODO.md` for the resumption work plan.
 
 - **v0.0.1 (MVP)** focuses on a correct, minimal foundation
 - **v1.0** adds aliases, editing, invitations, and public-sharing readiness

--- a/doc/design/patterns.md
+++ b/doc/design/patterns.md
@@ -382,6 +382,21 @@ checker can't prove the union satisfies the signature. Contain the
 `type: ignore` in one place — the glue function that owns both sides
 of the boundary. Tests bracket correctness from both ends.
 
+## Error Handling Patterns
+
+### Pattern: Error Skeleton First
+
+Establish three things before the error taxonomy grows:
+a single base error type carrying status and severity,
+one boundary that classifies only unexpected errors
+(never the catch path for expected ones),
+and one named builder per response surface (api, htmx, browser).
+The taxonomy of leaf errors always grows later and that is fine;
+the skeleton is what keeps the growth cheap.
+Retrofitting these onto a codebase that started without them is the expensive path:
+the same cross-cutting change has to be made at every layer at once,
+which is how partial migrations and silently deferred branches creep in.
+
 ## Principles
 
 - **Data structures are the spec**
@@ -398,3 +413,9 @@ of the boundary. Tests bracket correctness from both ends.
   - When the type checker fights you, the model is wrong. Investigate, don't suppress.
   - Only when python's type system can't express the design does it need to be bent.
   - Otherwise, let it guide you to better abstractions.
+- **Error skeleton before taxonomy**
+  - Base error type, one boundary for the unexpected, one builder per surface.
+  - Grow leaves into it.
+- **A deferral is not done until recorded**
+  - Closing work updates the deferral's tracking line in the same change.
+  - Refactors that resolve a deferral as a side effect still update the record.

--- a/doc/module/cli.md
+++ b/doc/module/cli.md
@@ -15,12 +15,39 @@ class DepoConfig:
     store_root: Path
     host: str           # default: "127.0.0.1"
     port: int           # default: 8765
-    max_size_bytes: int # default: 10_485_760
+    min_code_len: int   # default: 8
+    max_size_bytes: int # default: 2**26 (64 MiB)
     max_url_len: int    # default: 2048
-    log_level: str      # default: "WARNING"
+    log_level: Severity # default: Severity.WARNING
 ```
 
 Frozen dataclass. Immutable after resolution.
+
+## defaults.py
+
+Default value production for DepoConfig, separate from config.py's
+resolution logic.
+
+### Constants
+
+| Name | Default |
+|------|---------|
+| HOST | "127.0.0.1" |
+| PORT | 8765 |
+| MIN_CODE_LEN | 8 |
+| MAX_SIZE_BYTES | 2**26 (64 MiB) |
+| MAX_URL_LEN | 2048 |
+| LOG_LEVEL | Severity.WARNING |
+
+### Functions
+
+```python
+default_store_dir() -> Path
+default_db_path() -> Path
+```
+
+Resolve under `XDG_DATA_HOME/depo` when set,
+else cwd-relative for containerized deploys.
 
 ### Function
 

--- a/doc/module/service.md
+++ b/doc/module/service.md
@@ -42,7 +42,7 @@ class ContentClassification:
 
 Image metadata extraction. Soft dependency on Pillow.
 
-### Function
+### media.py - Function
 
 ```python
 get_image_info(data: bytes) -> ImageInfo
@@ -74,9 +74,9 @@ class IngestService:
     def __init__(
         self,
         *,
-        min_code_length: int = 8,
-        max_size_bytes: int = 2**20,
-        max_url_len: int = 2048,
+        min_code_len: int,
+        max_size_bytes: int,
+        max_url_len: int,
     ) -> None: ...
 
     def build_plan(

--- a/doc/planning/mvp.md
+++ b/doc/planning/mvp.md
@@ -232,19 +232,295 @@ surfaces (already wired and tested).*
 
 - [ ] gh pr create --title "Fix: Non-HTMX form fallback error surface" --body "..."
 
-### Auth
+### Users table and model (Branch: `ft/users-table`)
 
-Minimal auth to prevent open uploads on the public internet.
+*Problem: there is no user identity in the system. `items.uid` is an
+integer referencing nothing and auth has no table to authenticate
+against. Add a `users` table, a `User` domain model, and user repo CRUD,
+with `items.uid` gaining a foreign key to `users(id)`. Out of scope:
+password hashing and the provisioning command (owned by
+`ft/credentials`); login and session infrastructure (`ft/login-session`);
+the `/upload` gate (`ft/upload-gate`); `perm`/visibility enforcement
+(post-MVP, column already present and defaulting to PUBLIC).*
 
-- No anonymous uploads
-  - Guests disabled by default
-    - *(the config default to enforce once a guest/role concept exists)*
-    - moved here from Config and limits
-- Manual user provisioning (admin edits DB)
-- Username + password
-- Item has owner (`uid`) + visibility (`perm`)
-- `/upload` requires auth
-- `uid=0` superuser convention continues until user table exists
+#### Setup and gating test
+
+- [ ] Branch `ft/users-table` from main.
+- [ ] Add a skipped integration test to `tests/repo/test_sqlite.py`
+      (new `TestUserPersistence` class) asserting the end state: a `User`
+      inserted via the repo round-trips, fetch-by-id and fetch-by-email
+      each return a `User` equal to the inserted one. `@pytest.mark.skip`
+      until the last unit.
+  - [ ] Commit: `Tst: Add skipped gating test for user persistence round-trip`
+
+#### TDD implementation
+
+**Add the User domain model**
+(`tests/model/test_user.py`)
+
+- [ ] Red: add field-spec tests mirroring `TestItem` (`test_instance_dataclass`,
+      parametrized `test_fields` over `id`, `email`, `name`, `pw_hash`,
+      `created_at`, `test_frozen`, `test_instantiate`).
+- [ ] Add `src/depo/model/user.py`: frozen `kw_only` `User` dataclass,
+      all fields required, no optionals.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Add User domain model`
+
+**Add the make_user factory**
+(`tests/model/test_user.py`)
+
+- [ ] Red: add a test asserting `make_user()` returns a valid `User` and
+      that overrides apply.
+- [ ] Add `make_user(**overrides) -> User` to `tests/factories/models.py`
+      alongside the existing model factories.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Tst: Add make_user factory`
+
+**Add the users table and items.uid foreign key**
+(`tests/repo/test_sqlite.py`)
+
+- [ ] Red: add a test asserting the FK is enforced, inserting an item with
+      an unknown uid raises under `PRAGMA foreign_keys = ON`; and a test
+      asserting the seeded superuser row exists after `init_db`.
+- [ ] Edit `src/depo/repo/schema.sql`: add the `users` table above `items`
+      (`id INTEGER PRIMARY KEY`, `email TEXT NOT NULL UNIQUE`, `name TEXT
+      NOT NULL UNIQUE`, `pw_hash TEXT NOT NULL`, `created_at INTEGER NOT
+      NULL`); add `REFERENCES users(id)` to `items.uid`; seed the reserved
+      superuser row with an idempotent `INSERT OR IGNORE` carrying a
+      non-verifying `pw_hash` sentinel (no hashing exists until
+      `ft/credentials`; the superuser stays un-loginable until that PR
+      sets a real password) so the `uid` default has a referent.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Add users table and items.uid foreign key`
+
+**Add user repo CRUD**
+(`tests/repo/test_sqlite.py`)
+
+- [ ] Red: add tests for insert, fetch-by-id, fetch-by-email, and unique
+      violations on `email` and `name`; add an `insert_user` DB helper
+      delegating to `make_user`.
+- [ ] Add `_row_to_user`, `insert_user`, `get_user`, and
+      `get_user_by_email` to `src/depo/repo/sqlite.py`, following the
+      existing `_row_to_*` and insert idioms.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Add user repo CRUD`
+
+#### Integration and documentation
+
+- [ ] Unskip the `TestUserPersistence` gating test; confirm it passes.
+- [ ] Update `doc/module/model.md` (User model) and `doc/module/repo.md`
+      (user CRUD); note the `items.uid` foreign key wherever the schema is
+      documented.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Doc: ...`
+
+#### PR
+
+- [ ] gh pr create --title "Ft: Users table and model" --body "..."
+
+### Password credentials and provisioning (Branch: `ft/credentials`)
+
+*Problem: users have a `pw_hash` column but nothing produces or
+verifies a hash, and manual provisioning via raw SQL cannot compute
+one. Add a stdlib credentials module (scrypt hashing, constant-time
+verify) and a click create-user command that writes a row with a
+valid hash. Depends on `ft/users-table`. Out of scope: login route
+and sessions (`ft/login-session`); the `/upload` gate
+(`ft/upload-gate`); email-based provisioning flows (post-MVP).
+Assumes `ref/canonical-config` has landed: scalar defaults live in
+`cli/defaults.py` and `DepoConfig` sources from them.*
+
+#### Setup and gating test
+
+- [ ] Branch `ft/credentials` from `ft/users-table`.
+- [ ] Add a skipped integration test to `tests/cli/test_main.py` (new
+      `TestCreateUser` class) asserting the end state: invoking the
+      create-user command with email, name, and password writes a
+      `users` row whose stored `pw_hash` verifies against the password
+      and rejects a wrong one. `@pytest.mark.skip` until the last unit.
+  - [ ] Commit: `Tst: Add skipped gating test for user provisioning`
+
+#### TDD implementation
+
+**Hash and verify passwords with stdlib scrypt**
+(`tests/util/test_password.py`)
+
+- [ ] Red: tests asserting `hash_password(pw, *, n, r, p)` returns a
+      self-describing PHC-style string (algorithm, params, salt_hex,
+      digest_hex), `verify_password(pw, stored)` is true for the right
+      password and false for a wrong one, two hashes of the same
+      password differ (random salt), and a tampered field fails verify.
+- [ ] Add `src/depo/util/password.py`: `hash_password` using
+      `hashlib.scrypt` with an `os.urandom` salt, hex-encoded
+      (`bytes.hex`) into a PHC-style string; `verify_password` parsing
+      it (`bytes.fromhex`), recomputing, and comparing with
+      `hmac.compare_digest`. Stdlib only, no new dependency. Do not
+      reuse the Crockford codec (encode-only, built for shortcodes).
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Add scrypt password hashing and verification`
+
+**Add scrypt cost parameters to config**
+(`tests/cli/test_defaults.py`, `tests/cli/test_config.py`)
+
+- [ ] Red: test asserting `DepoConfig` exposes scrypt cost fields with
+      sane defaults sourced from `cli/defaults.py`, and a resolution
+      test that an overridden value (env or TOML) coerces to int onto
+      the config, mirroring the existing override tests.
+- [ ] Add `DEFAULT_SCRYPT_N` (2**14), `DEFAULT_SCRYPT_R` (8),
+      `DEFAULT_SCRYPT_P` (1) to `cli/defaults.py`; add
+      `scrypt_n`/`scrypt_r`/`scrypt_p` fields to `DepoConfig` sourcing
+      them; add the three names to the `_coerce` `int_fields` set.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Add scrypt cost parameters to config`
+
+**Add the create-user click command**
+(`tests/cli/test_main.py`)
+
+- [ ] Red: tests asserting the command creates a user with a verifying
+      hash, errors on duplicate email or name (surfacing the repo
+      unique violation), and reads the password without echoing it.
+- [ ] Add a `create-user` command on the `cli` group in
+      `src/depo/cli/main.py` taking email and name as options and the
+      password via a hidden prompt (`click.password_option` or
+      `prompt=..., hide_input=True`); hash via `hash_password` with
+      cost params from the resolved config, write the row via
+      `insert_user`.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Add create-user admin command`
+
+#### Integration and documentation
+
+- [ ] Unskip the `TestCreateUser` gating test; confirm it passes.
+- [ ] Update `doc/module/util.md` (password module) and
+      `doc/module/cli.md` (create-user command); note the scrypt cost
+      params wherever config fields are documented.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Doc: ...`
+
+#### PR
+
+- [ ] gh pr create --title "Ft: Password credentials and provisioning" --body "..."
+
+### Login and session (Branch: `ft/login-session`)
+
+*Problem: users can be created and their passwords verified, but no
+request is ever recognized as logged in. Add a stateless signed-cookie
+session, a login route that verifies credentials and starts a session, a
+logout that ends it, and a single seam that reads the current user id
+from a request. Branch from `ft/credentials`. Assumes `ref/canonical-config`
+has landed (scalar defaults in `cli/defaults.py`, `DepoConfig` sources
+from them, `_coerce` typed field sets) and that `ft/credentials` provides
+`verify_password` and `ft/users-table` provides `get_user_by_email`. Out
+of scope: the `/upload` gate and `require_auth` as a route dependency
+(`ft/upload-gate`, which consumes the `get_current_uid` seam this PR
+builds); CSRF tokens (v1, tracked); server-side session store and
+revocation (post-MVP, tracked); email login and password reset (post-MVP).*
+
+#### Setup and gating test
+
+- [ ] Branch `ft/login-session` from `ft/credentials`.
+- [ ] Add a skipped integration test to `tests/web/test_routes.py` (new
+      `TestLoginSession` class) asserting the end state: POSTing valid
+      credentials to `/login` establishes a session such that a subsequent
+      request is recognized as that user; bad credentials are rejected and
+      re-render the form; `/logout` clears the session so a following
+      request is unauthenticated. `@pytest.mark.skip` until the last unit.
+  - [ ] Commit: `Tst: Add skipped gating test for login and session`
+
+#### TDD implementation
+
+**Add the itsdangerous dependency and session config**
+(`tests/cli/test_defaults.py`, `tests/cli/test_config.py`, make_config tests)
+
+- [ ] Add `itsdangerous` to `pyproject.toml` dependencies (Starlette
+      `SessionMiddleware` requires it for cookie signing); sync the env.
+- [ ] Red: tests asserting `DepoConfig` exposes `session_secret` and
+      `session_https_only` sourced from `cli/defaults.py`; overrides (env
+      or TOML) resolve onto the config; an empty or missing
+      `session_secret` hard-fails rather than signing with a known value;
+      `session_https_only` coerces to bool and defaults False.
+- [ ] Add `DEFAULT_SESSION_SECRET = ""` (empty force-fail sentinel) and
+      `DEFAULT_SESSION_HTTPS_ONLY = False` (plain-HTTP LAN selfhost is the
+      MVP deployment; secure-only cookies would never be sent) to
+      `cli/defaults.py`; add `session_secret: str` and
+      `session_https_only: bool` fields to `DepoConfig` sourcing them; add
+      them to `_coerce` (secret as string, https_only to the bool set);
+      validate `session_secret` non-empty at resolution.
+- [ ] Update `make_config` in `tests/factories` to supply a non-empty
+      `session_secret` default so fixtures built from it pass the
+      non-empty validation; add a test that the default is present.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Add itsdangerous and session config`
+
+**Wire SessionMiddleware and the current-user seam**
+(`tests/web/test_app.py`, `tests/web/test_routes.py`)
+
+- [ ] Red: test asserting `request.session` is populated inside a handler
+      (fails if the middleware is not actually in the stack); an
+      unauthenticated request resolves to no current user (not a default
+      uid, not a 500); a tampered or forged session cookie is rejected as
+      unauthenticated; and a `uid` set in the session round-trips back
+      from `get_current_uid` as an `int` (PR 4 keys auth off the type).
+- [ ] In `app_factory` (`web/app.py`) call `app.add_middleware(
+      SessionMiddleware, secret_key=config.session_secret,
+      https_only=config.session_https_only, same_site="lax")` (the cookie
+      is httponly by default). `add_middleware` wraps the whole app
+      including the routers regardless of call order relative to
+      `include_router`, but place it explicitly in `app_factory` so it is
+      unambiguous. Add `get_current_uid(request) -> int | None` to
+      `web/deps.py` reading `request.session.get("uid")`; this is the only
+      function aware of `request.session` and is the seam `require_auth`
+      consumes in PR 4.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Wire SessionMiddleware and current-user seam`
+
+**Add the login route**
+(`tests/web/test_routes.py`)
+
+- [ ] Red: tests asserting GET `/login` renders the login form page; POST
+      with valid credentials clears any prior session, sets `uid`, and
+      redirects; POST with a wrong password and POST with an unknown email
+      both re-render the form with a generic error and identical surface
+      (no user-enumeration difference); neither logs the password.
+- [ ] Add `web/routes/auth.py` with a `page_login` GET handler rendering a
+      new `templates/auth/login.html` (mirroring the `page_upload` +
+      `upload/page.html` idiom) and a POST handler that calls
+      `get_user_by_email` then `verify_password`; on success
+      `request.session.clear()` then sets `request.session["uid"]` and
+      redirects (302); on failure re-renders the form with an error in the
+      page body (page idiom, not the error builders). Register the auth
+      router in `routes/__init__.py` among the `include_router` calls but
+      before `shortcode_router` (the wildcard `/{code}` must stay last).
+      Add `templates/auth/login.html` extending `base.html`.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Add login route`
+
+**Add the logout route**
+(`tests/web/test_routes.py`)
+
+- [ ] Red: test asserting `/logout` clears the session, a subsequent
+      request is unauthenticated, and logout redirects.
+- [ ] Add a logout handler to `web/routes/auth.py` that calls
+      `request.session.clear()` and redirects (302). Register on the auth
+      router.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Add logout route`
+
+#### Integration and documentation
+
+- [ ] Unskip the `TestLoginSession` gating test; confirm it passes.
+- [ ] Update `doc/module/web.md` (session middleware, `get_current_uid`
+      seam, login/logout routes), `doc/module/templates.md` (auth/login
+      template), and add `/login` and `/logout` to the reserved-namespaces
+      list in `doc/design/routes.md`. Note the `session_secret` and
+      `session_https_only` config fields wherever config fields are
+      documented.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Doc: ...`
+
+#### PR
+
+- [ ] gh pr create --title "Ft: Login and session" --body "..."
 
 ### Global Chrome & Layout Realignment (nav / main / footer / base.html)
 

--- a/doc/planning/mvp.md
+++ b/doc/planning/mvp.md
@@ -136,26 +136,101 @@ guests-disabled-by-default (moved to Auth).*
 
 - [ ] gh pr create --title "Ref: Canonical config" --body "..."
 
-### Non-HTMX form fallback error handling (needs planning)
+### Non-HTMX form fallback error surface (Branch: `fix/form-error-surface`)
 
-Problem: the `application/x-www-form-urlencoded` fallback branch in the
+*Problem: the `application/x-www-form-urlencoded` fallback branch in the
 upload dispatcher (`web/routes/upload.py`) runs `_parse_form_upload` and
-`orch.ingest` with no `except DepoError`. Expected domain errors (empty,
-oversized, bad format) on a non-HTMX form POST escape to the app-level
-boundary, which wraps them as `UnknownServerError` and renders a 500. This
-mislabels ordinary 4xx domain errors as server errors and discards their
-real status and message.
+`orch.ingest` with no `except DepoError`, so expected domain errors (empty,
+oversized, bad format) on a non-HTMX form POST escape to the boundary, which
+wraps them as `UnknownServerError` and renders a 500. This mislabels ordinary
+4xx as server errors and discards their true status and message. Compounding
+it, a bad `format=` token raises a raw `ValueError` from `ContentFormat(fmt)`
+at three sites (form parse file branch, form parse text branch, and
+`api_upload`), which escapes even a bare `except DepoError`. Decision: the
+form path renders full-page `browser_error` at the error's true status; the
+success 303 redirect to `/{code}/info` is unchanged. Coercion is normalized
+through `format_for_extension` (alias-tolerant, returns None on unknown), with
+the web layer raising `UnsupportedFormatError` on None so the model layer stays
+free of web-error semantics. Out of scope: redirect-with-flash (no flash or
+session infrastructure exists, not introducing it); FormatMismatchError
+(unplanned, unrelated to unsupported-token coercion); the htmx and api error
+surfaces (already wired and tested).*
 
-This was assumed closed by the `ref/error-boundary` boundary handler. It is
-not: the boundary is for unexpected errors and must not be the catch path
-for expected ones. The fix is entangled with the fallback's success shape
-(currently a 303 redirect, no error render of its own), so the surface and
-flow need a design decision, not a patch.
+#### Setup and gating test
 
-To plan: what the non-HTMX form path renders on a DepoError (full-page
-browser_error, redirect-with-flash, or other), whether the success redirect
-stays, and how this interacts with the deferred non-404 4xx browser
-templates. Plan alongside request access logging.
+- [ ] Branch `fix/form-error-surface` from main.
+- [ ] Add a skipped integration test to `tests/web/routes/test_upload.py`
+      (new `TestFormFallbackError` class) asserting the end state: a non-HTMX
+      form POST (`t_client.post`, `data=...`, no `HEADER_HTMX`) that triggers
+      a domain error renders full-page HTML at the error's true 4xx status,
+      not 500 and not plaintext. Assert `status_code == 400` for an empty
+      submission (PayloadEmptyError is 400), `text/html` content-type, and the
+      `errors/page.html` marker in the body via BeautifulSoup.
+      `@pytest.mark.skip` until the last unit.
+  - [ ] Commit: `Tst: Add skipped gating test for form fallback error surface`
+
+#### TDD implementation
+
+**Normalize format-token coercion through `format_for_extension`**
+(`tests/web/routes/test_upload.py`)
+
+- [ ] Red: add a parse-unit test to `TestParseFormUpload` asserting a bad
+      `format` token on non-empty content raises `UnsupportedFormatError`
+      (use `_test_fn("hello", "bogus")`; non-empty content avoids the
+      `PayloadEmptyError` short-circuit).
+- [ ] Replace the three `ContentFormat(fmt)` call sites in `upload.py`
+      (`_parse_form_upload` file branch, text branch, and `api_upload`'s
+      `req_fmt`) with `format_for_extension(...)`, raising
+      `UnsupportedFormatError(fmt)` when it returns None. Import
+      `format_for_extension` and `UnsupportedFormatError`.
+- [ ] Confirm `test_request_format_for_select_option` stays green
+      (refactor-under-green: canonical tokens still resolve, so the existing
+      assertion is the regression guard for the swap).
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Fix: Normalize format-token coercion, raise UnsupportedFormatError`
+
+**Surface bad API-path format token as 422**
+(`tests/web/routes/test_upload.py`)
+
+- [ ] Red: add a test under `TestApiUploadError` asserting `?format=bogus`
+      returns 422, mirroring `test_oversized_returns_413`. The coercion swap
+      from the prior unit already routes this through `api_upload`'s existing
+      `except DepoError`, so this asserts the now-correct API surface
+      end to end.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Tst: Assert API-path bad format token returns 422`
+
+**Wire form fallback branch to `browser_error`**
+(`tests/web/routes/test_upload.py`)
+
+- [ ] Red: add form-branch tests (`TestFormFallbackError`) asserting an
+      oversized non-HTMX form POST renders full-page HTML at 413, and a
+      bad-format one at 422 (full surface, distinct from the empty-content
+      400 the gating test covers).
+- [ ] In `upload.py`, wrap the form fallback branch's `_parse_form_upload` and
+      `orch.ingest` in `try/except DepoError as e: return browser_error(req, e)`.
+      Import `browser_error`. Catch `DepoError` broadly; `e.status` drives the
+      response. Leave the 303 success path unchanged.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Fix: Render browser_error on non-HTMX form fallback DepoError`
+
+#### Integration and documentation
+
+- [ ] Unskip the `TestFormFallbackError` gating test; confirm it passes.
+- [ ] Update `doc/design/errors.md` Deferred section: remove the
+      form-fallback entry (closed by this PR) and mark the non-404 4xx
+      browser-template entry resolved (the error rearchitecture made
+      `errors/page.html` render any status generically; the note drifted
+      out of sync and was never updated).
+- [ ] Note in errors.md that `FormatMismatchError` (unplanned) is unrelated
+      and untouched, to prevent a future reader conflating it with the
+      unsupported-token coercion landed here.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Doc: ...`
+
+#### PR
+
+- [ ] gh pr create --title "Fix: Non-HTMX form fallback error surface" --body "..."
 
 ### Auth
 

--- a/doc/planning/mvp.md
+++ b/doc/planning/mvp.md
@@ -255,6 +255,26 @@ the `/upload` gate (`ft/upload-gate`); `perm`/visibility enforcement
 
 #### TDD implementation
 
+**Enable WAL journal mode and busy timeout**
+(`tests/repo/test_sqlite.py`)
+
+- [ ] Red: test asserting `PRAGMA journal_mode` resolves to `wal` after
+      `init_db`, and that `busy_timeout` is set on the connection (so a
+      separate-process writer, the `set-password` command in
+      `ft/credentials`, can commit without `database is locked`).
+- [ ] In `init_db` (`src/depo/repo/sqlite.py`) add `PRAGMA journal_mode =
+      WAL`, `PRAGMA busy_timeout = <ms>`, and `PRAGMA synchronous =
+      NORMAL` beside the existing `PRAGMA foreign_keys = ON`.
+      `journal_mode` persists in the DB file; `busy_timeout` is
+      per-connection, set on every `init_db` call (server and CLI alike).
+      Out of scope: thread-safety of the web app's shared connection
+      (the `app.py` thread-pooling/write-queuing note is a separate
+      deferred concern; WAL does not address it).
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Enable WAL journal mode and busy timeout`
+
+**Add the User domain model**
+
 **Add the User domain model**
 (`tests/model/test_user.py`)
 
@@ -305,12 +325,26 @@ the `/upload` gate (`ft/upload-gate`); `perm`/visibility enforcement
 - [ ] uv run ruff check && uv run pytest
 - [ ] Commit: `Ft: Add user repo CRUD`
 
+**Add user password-hash update**
+(`tests/repo/test_sqlite.py`)
+
+- [ ] Red: test asserting `update_user_pw_hash(uid, new_hash)` changes
+      the stored `pw_hash` for an existing user (fetch confirms the new
+      value) and that an unknown uid raises `NotFoundError`.
+- [ ] Add `update_user_pw_hash(uid, new_hash)` to
+      `src/depo/repo/sqlite.py` following the existing write idioms: a
+      single `UPDATE users SET pw_hash = ? WHERE id = ?`, raising
+      `NotFoundError` when no row is affected.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Add user password-hash update`
+
 #### Integration and documentation
 
 - [ ] Unskip the `TestUserPersistence` gating test; confirm it passes.
 - [ ] Update `doc/module/model.md` (User model) and `doc/module/repo.md`
-      (user CRUD); note the `items.uid` foreign key wherever the schema is
-      documented.
+      (user CRUD, `update_user_pw_hash`, and the WAL / busy_timeout /
+      synchronous connection config); note the `items.uid` foreign key
+      wherever the schema is documented.
 - [ ] uv run ruff check && uv run pytest
 - [ ] Commit: `Doc: ...`
 
@@ -388,12 +422,30 @@ Assumes `ref/canonical-config` has landed: scalar defaults live in
 - [ ] uv run ruff check && uv run pytest
 - [ ] Commit: `Ft: Add create-user admin command`
 
+**Add the set-password admin command**
+(`tests/cli/test_main.py`)
+
+- [ ] Red: tests asserting the command changes an existing user's
+      password (the new password verifies via `verify_password`, the old
+      no longer does), accepts either an email or a numeric id and
+      resolves an email through `get_user_by_email` to a uid, errors
+      cleanly if the user does not exist, and reads the new password via
+      a hidden prompt without echoing it.
+- [ ] Add a `set-password` command on the `cli` group in
+      `src/depo/cli/main.py`: resolve the target to a uid (numeric id used
+      directly; email looked up via `get_user_by_email`), hash the new
+      password via `hash_password` with cost params from the resolved
+      config, and write via `update_user_pw_hash`. Surface a clean CLI
+      error (not a traceback) when the user is not found.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Add set-password admin command`
+
 #### Integration and documentation
 
 - [ ] Unskip the `TestCreateUser` gating test; confirm it passes.
 - [ ] Update `doc/module/util.md` (password module) and
-      `doc/module/cli.md` (create-user command); note the scrypt cost
-      params wherever config fields are documented.
+      `doc/module/cli.md` (create-user and set-password commands); note
+      the scrypt cost params wherever config fields are documented.
 - [ ] uv run ruff check && uv run pytest
 - [ ] Commit: `Doc: ...`
 
@@ -521,6 +573,170 @@ revocation (post-MVP, tracked); email login and password reset (post-MVP).*
 #### PR
 
 - [ ] gh pr create --title "Ft: Login and session" --body "..."
+
+### Upload gate (Branch: `ft/upload-gate`)
+
+*Problem: any anonymous visitor can POST to `/upload` and create items
+with the default `uid=0`. The MVP-critical requirement is that no
+anonymous POST is ever possible. Add a web-layer `require_auth`
+dependency that gates both `/upload` routes, a 401 `AuthRequiredError`,
+and thread the authenticated uid into the existing ingest path so items
+persist with the real uploader's id instead of 0. Branch from
+`ft/login-session`. PRECONDITION: this branches only AFTER
+`fix/form-error-surface` has merged (auth adds an unauthenticated path
+to the same upload dispatcher and relies on that dispatcher's error
+surfaces being correct); confirm it has landed before branching. Out of
+scope: `perm`/visibility enforcement and any 403/ownership checks
+(post-MVP, the column is present and ingest already passes the PUBLIC
+default); roles and user relations (post-MVP); per-item ownership on
+read/delete (post-MVP); CSRF (v1, tracked); rate limiting (post-MVP);
+gating any route other than the two `/upload` routes.*
+
+*Open decision (resolve before the require_auth and gate units): the auth
+failure raises `AuthRequiredError(DepoError, status=401)`. The per-surface
+response is settled in intent: plain browser 302 to `/login`, pure API a
+plain 401, HTMX a client navigation to `/login` (via `HX-Redirect`) rather
+than an inline error. Two coupled things are UNRESOLVED. First, the HTMX
+case does NOT fit `htmx_error`'s established contract (200 + an error
+partial in the body); an `HX-Redirect` navigation is a distinct response,
+so either `htmx_error` learns a redirect mode or the HTMX auth failure
+short-circuits to a dedicated redirect response that never enters the
+error-partial path. Second, where the redirect-vs-render negotiation lives:
+(a) `require_auth` raises and the three builders negotiate surface
+(centralizes it but couples the generic error seam to auth-specific
+redirect logic), or (b) `require_auth` returns the redirect directly for
+browser/HTMX context and only raises for API (keeps the builders generic
+but splits the gate's behavior by surface), or (c) `AuthRequiredError`
+carries a redirect target and the builders gain a generic
+redirect-instead-of-render rule (reusable, larger builder-contract change).
+The require_auth unit below is written assuming (a)/(c) (it raises); if (b)
+is chosen, that unit changes to return-redirect-for-browser-context. All
+three interact with `fix/form-error-surface`, which reshapes the same
+builders, so confirm that branch's final builder shape before implementing
+either the require_auth or the gate units.*
+
+Mechanics note on (b): a FastAPI `Depends` cannot short-circuit by
+returning a `Response`; a returned value only populates the parameter.
+So "return the redirect" is not directly possible. (b) in practice means
+raising a redirect-carrying exception handled at the boundary, which
+collapses it toward (c). Pick (b) only with that understanding.
+
+#### Setup and gating test
+
+- [ ] Confirm `fix/form-error-surface` has merged; branch
+      `ft/upload-gate` from `ft/login-session`.
+- [ ] Add a skipped integration test to `tests/web/test_routes.py` (new
+      `TestUploadGate` class) asserting the MVP guarantee end to end: an
+      unauthenticated POST `/upload` is rejected and creates no item; an
+      authenticated client (session established via `/login`) POST
+      `/upload` creates an item whose `uid` is the logged-in user, not 0.
+      Assert the invariant (rejected, no item, correct uid on success),
+      NOT the per-surface mechanism (302 vs `HX-Redirect` vs error
+      partial) which the builder open-decision settles and the per-route
+      gate units assert. `@pytest.mark.skip` until the last unit.
+  - [ ] Commit: `Tst: Add skipped gating test for upload gate`
+
+#### TDD implementation
+
+**Add the AuthRequiredError type**
+(`tests/util/test_errors.py`)
+
+- [ ] Red: tests asserting `AuthRequiredError` is a `DepoError` subclass
+      with status 401 and `Severity.INFO` (unauthenticated traffic is
+      expected, not a fault), and a pass-through constructor. Add
+      `AuthRequiredError: Severity.INFO` to the gap-test `EXPECTED` dict
+      so `descendants(DepoError) == set(EXPECTED)` still holds (a new
+      concrete error without a severity decision fails the suite).
+- [ ] Add `AuthRequiredError(DepoError)` to `src/depo/util/errors.py` as
+      a new top-level domain base (parallel to `RepoError` /
+      `ValidationError`): `status = 401`, `severity = Severity.INFO`,
+      pass-through `__init__`.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Add AuthRequiredError type`
+
+**Thread authenticated uid through ingest**
+(`tests/service/test_orchestrator.py`)
+
+- [ ] Red: test asserting `ingest(uid=N)` persists an item with
+      `items.uid == N` (currently `ingest` accepts `uid` but drops it:
+      the `self._repo.insert(plan)` call omits it, so a non-default uid
+      never reaches the row).
+- [ ] In `IngestOrchestrator.ingest` (`src/depo/service/orchestrator.py`)
+      pass the param through: `self._repo.insert(plan, uid=uid)`.
+      `repo.insert` already accepts and writes `uid`; this is the missing
+      link, not a repo change.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Thread authenticated uid through ingest`
+
+**Add the require_auth dependency**
+(`tests/web/test_deps.py`, new)
+
+- [ ] Red: tests asserting `require_auth` yields the uid when a valid
+      session is present, and raises `AuthRequiredError` when there is no
+      session uid. Built on `get_current_uid` (PR 3); yields the bare uid
+      (the upload path only needs the int, and this keeps `pw_hash` out
+      of request scope). For MVP, yielding the session uid without a
+      confirming user fetch is acceptable: `items.uid` is FK-checked at
+      insert, so a stale-cookie / deleted-user uid fails at the FK rather
+      than persisting. (If the chosen design instead fetches to validate,
+      a missing row is an auth failure, raise `AuthRequiredError`, not a
+      500.)
+- [ ] Add `require_auth(request) -> int` to `src/depo/web/deps.py`,
+      reading `get_current_uid` and raising `AuthRequiredError` on None.
+      (Written assuming open-decision option (a)/(c): raises, builders
+      negotiate. Under (b) this returns a redirect for browser/HTMX
+      context and raises only for API.)
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Add require_auth dependency`
+
+**Gate POST /upload and pass uid to ingest**
+(`tests/web/test_routes.py`)
+
+- [ ] Red: tests asserting an unauthenticated POST `/upload` is rejected
+      and creates no item, and an authenticated POST creates an item with
+      the session user's uid. Assert the per-surface mechanism settled by
+      the open decision (401 api; HTMX client-navigation to `/login`;
+      302 to `/login` for a non-HTMX form). Cover the dispatcher and both
+      `hx_`/`api_` paths.
+- [ ] Wire `require_auth` into the `upload` dispatcher in
+      `src/depo/web/routes/upload.py` via `Depends(require_auth)`, and
+      pass the yielded uid into `orch.ingest(uid=...)` in the dispatcher
+      and the `hx_`/`api_`/`_ingest_upload` call sites that currently call
+      `ingest` with no uid.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Gate POST /upload and pass uid to ingest`
+
+**Gate GET /upload (the form)**
+(`tests/web/test_routes.py`)
+
+- [ ] Red: tests asserting an unauthenticated GET `/upload` does not
+      render the form and redirects to `/login` (302 for a browser; the
+      HTMX-GET case, if the form is ever fetched via HTMX, uses the same
+      client-navigation mechanism settled in the open decision), and an
+      authenticated GET renders the form.
+- [ ] Wire `require_auth` into `page_upload` in
+      `src/depo/web/routes/upload.py` via `Depends(require_auth)`.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ft: Gate GET /upload form`
+
+#### Integration and documentation
+
+- [ ] Unskip the `TestUploadGate` gating test; confirm it passes.
+- [ ] Update `doc/module/web.md` (`require_auth`, the gated `/upload`
+      routes), `doc/module/util.md` and `doc/design/errors.md`
+      (`AuthRequiredError`, the new 401 top-level domain base), and
+      `doc/module/service.md` (ingest now threads uid to the row).
+- [ ] Record a post-MVP item in the post-MVP planning doc: examine
+      moving `pw_hash` into a dedicated `credentials` table associated to
+      a user (keeps `users`/`User` hash-free by construction, confines
+      the hash to the credential layer, room for multiple auth methods
+      per user). Open: one-to-one vs one-to-many; when it lands.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Doc: ...`
+
+#### PR
+
+- [ ] gh pr create --title "Ft: Upload gate" --body "..."
 
 ### Global Chrome & Layout Realignment (nav / main / footer / base.html)
 

--- a/doc/planning/mvp.md
+++ b/doc/planning/mvp.md
@@ -30,18 +30,111 @@ service, repo, and storage. Dedupe by content hash.
 
 Ordered by dependency. Each heading is roughly one PR.
 
-### Config and limits
+### Canonical config (Branch: `ref/canonical-config`)
 
-- Raise default upload limit to 64MiB (`max_size_bytes` = 67_108_864);
-  - guests disabled by default
-- Refactor size limits to use the config loading infrastructure
-- Set up local dev/manual testing config in XDG paths
-- Access tracking per item (UPDATE on access for recent/popular surfacing,
-  naive first, optimize later)
-- Unify `payload_bytes`/`payload_path` into `payload: bytes | Path`:
-  - Use `isinstance` dispatch.
-  - Reduces null coalescing throughout ingest pipeline.
-  - Related to temp file streaming and async pipeline work.
+*Problem: DepoConfig mixes value production with override-resolution
+logic, and the resolved config never reaches IngestService.
+Scalar defaults are inline literals on the dataclass;
+the path factories (_default_store_dir, _default_db_path)
+compute defaults but live beside the resolution chain;
+and app_factory builds IngestService() with no arguments,
+so its local defaults for min_code_length, max_size_bytes,
+and max_url_len govern at runtime while the resolved config values are dead.
+Extract all value production into a new cli/defaults.py
+(scalar constants plus the renamed public path helpers and their tests),
+leaving config.py as slim structuring and override logic.
+Source DepoConfig fields from defaults.py,
+raise the max_size_bytes default to 64 MiB (2**26),
+add min_code_length as a config field,
+and wire all three resolved fields into IngestService at app_factory,
+dropping the service's local defaults so they are required.
+Out of scope:
+the override chain and config-file discovery
+(_xdg_config_home, load_config layering), confirmed working and untouched;
+guests-disabled-by-default (moved to Auth).*
+
+#### Setup and gating test
+
+- [ ] Add `**overrides` to the make_config factory; small green test
+      that an override reaches the returned config.
+  - [ ] Commit: `Tst: Add overrides to make_config factory`
+- [ ] Add skipped TestConfigWiring class to tests/web/test_app.py: three
+      tests, one per field, each asserting the config value governs the
+      live API upload path (tiny max_size_bytes rejects any upload, tiny
+      max_url_len rejects a link, raised min_code_length yields a code of
+      exactly that length on an empty repo via X-Depo-Code).
+  - [ ] Commit: `Tst: Add skipped gating tests for canonical config`
+
+#### TDD implementation
+
+**Relocate path-discovery helpers to cli/defaults.py**
+(`tests/cli/test_defaults.py`)
+
+- [ ] Stub cli/defaults.py with module header; move and rename
+      _default_store_dir -> default_store_dir,_default_db_path ->
+      default_db_path; reference via defaults namespace in config.py.
+- [ ] Move the four path-factory tests from test_config.py to
+      test_defaults.py (refactor-under-green).
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ref: Relocate path-discovery helpers to cli/defaults.py`
+
+**Source DepoConfig scalars from cli/defaults.py**
+(`tests/cli/test_config.py`, `tests/cli/test_defaults.py`)
+
+- [ ] Add scalar constants to defaults.py: DEFAULT_HOST, DEFAULT_PORT,
+      DEFAULT_MAX_SIZE_BYTES = 2**26, DEFAULT_MAX_URL_LEN,
+      DEFAULT_LOG_LEVEL.
+- [ ] Update test_config.py default assertions: max_size_bytes
+      10_485_760 -> 2**26 (the bump red).
+- [ ] Rewire DepoConfig scalar fields to reference the constants.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ref: Source DepoConfig scalars from cli/defaults.py`
+
+**Add min_code_length to DepoConfig**
+(`tests/cli/test_config.py`, `tests/cli/test_defaults.py`)
+
+- [ ] Add DEFAULT_MIN_CODE_LENGTH = 8 to defaults.py; add
+      min_code_length field to DepoConfig sourcing it; add
+      min_code_length to_coerce int_fields.
+- [ ] Red: resolution test that an overridden min_code_length (env or
+      TOML) resolves onto the config, mirroring existing override tests.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ref: Add min_code_length to DepoConfig`
+
+**Route test IngestService construction through a factory**
+(`tests/factories/`, `tests/service/`, `tests/fixtures/`)
+
+- [ ] Add make_ingest_service(**overrides) to tests/factories with sane
+      defaults for the three limit fields.
+- [ ] Migrate all IngestService() / IngestService(...) sites in
+      test_ingest.py and test_orchestrator.py, and t_orch_env, to the
+      factory (refactor-under-green: production defaults still exist).
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Tst: Route IngestService construction through factory`
+
+**Wire resolved config into IngestService** (`tests/web/test_app.py`)
+
+- [ ] Drop the local defaults from IngestService.**init**; make
+      min_code_length, max_size_bytes, max_url_len required.
+- [ ] In app_factory, construct IngestService with all three threaded
+      from app.state.config.
+- [ ] Unskip the three TestConfigWiring gating tests (the red for this
+      unit); minimal green.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Ref: Wire resolved config into IngestService`
+
+#### Integration and documentation
+
+- [ ] Confirm the three gating tests pass unskipped.
+- [ ] Update affected doc/module reference docs (cli.md and service.md
+      carry stale max_size_bytes values; new cli/defaults.py needs an
+      entry linked from the cli module README). Dev decides final scope.
+- [ ] uv run ruff check && uv run pytest
+- [ ] Commit: `Doc: ...`
+
+#### PR
+
+- [ ] gh pr create --title "Ref: Canonical config" --body "..."
 
 ### Non-HTMX form fallback error handling (needs planning)
 
@@ -69,6 +162,9 @@ templates. Plan alongside request access logging.
 Minimal auth to prevent open uploads on the public internet.
 
 - No anonymous uploads
+  - Guests disabled by default
+    - *(the config default to enforce once a guest/role concept exists)*
+    - moved here from Config and limits
 - Manual user provisioning (admin edits DB)
 - Username + password
 - Item has owner (`uid`) + visibility (`perm`)

--- a/doc/planning/unplanned.md
+++ b/doc/planning/unplanned.md
@@ -1,5 +1,26 @@
 # Unplanned Future Features/Architecture
 
+## Deferred: Preflight error domain
+
+Introduce a `PreflightError(DepoError)` base class for startup-time
+failures that occur before the server serves any request: invalid
+config, DB missing or corrupt, unreachable file store. Reparent
+`ConfigError` under it. Refine `ConfigError`'s signature with a
+free-form `reason`/`hint` field for problems that are not a bad value
+against a known set (malformed int, unreadable TOML), and thread
+config-source provenance so messages can name the origin (env var,
+TOML path, flag). post-MVP.
+
+## Deferred: Narrow per-consumer config slices
+
+`app_factory` currently unpacks `DepoConfig` fields explicitly when
+constructing inner-layer components (e.g. `IngestService`). If
+per-component arg lists grow painful, introduce narrow frozen
+dataclasses or Protocols carrying only the fields each component
+needs, adapted from `DepoConfig` at the composition root. Do not
+inject `DepoConfig` directly into inner layers; that violates the
+inward-only dependency rule. post-MVP.
+
 ## Future: Repository Architecture
 
 The current SQLite implementation lives in a single module (`repo/sqlite.py`).

--- a/src/depo/cli/config.py
+++ b/src/depo/cli/config.py
@@ -15,6 +15,8 @@ import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from depo.util.errors import ConfigError, Severity
+
 _XDG_DATA_HOME = "XDG_DATA_HOME"
 
 
@@ -46,7 +48,7 @@ class DepoConfig:
     max_size_bytes: int = 10_485_760
     max_url_len: int = 2048
     # Logging/ErrorHandling
-    log_level: str = "WARNING"
+    log_level: Severity = Severity.WARNING
 
 
 def _xdg_config_home() -> Path:
@@ -73,6 +75,12 @@ def _coerce(overrides: dict) -> dict:
             out[k] = int(v)
         elif k in path_fields:
             out[k] = Path(v).expanduser()
+        elif k == "log_level":  # Special case, needs to be a Severity enum member
+            try:
+                out[k] = Severity[str(v).upper()]
+            except KeyError:
+                err = ConfigError("log_level", v, expected=Severity.__members__)
+                raise err from None
         else:
             out[k] = v
     return out

--- a/src/depo/cli/config.py
+++ b/src/depo/cli/config.py
@@ -15,23 +15,8 @@ import tomllib
 from dataclasses import dataclass, field
 from pathlib import Path
 
+from depo.cli import defaults
 from depo.util.errors import ConfigError, Severity
-
-_XDG_DATA_HOME = "XDG_DATA_HOME"
-
-
-def _default_store_dir() -> Path:
-    """Return XDG_DATA_HOME/depo if set, else ./store for containerized deploys."""
-    if xdg := os.environ.get(_XDG_DATA_HOME):
-        return Path(xdg) / "depo" / "store"
-    return Path.cwd() / "store"
-
-
-def _default_db_path() -> Path:
-    """Return default database path. XDG_DATA_HOME/depo/depo.db or ./depo.db."""
-    if xdg := os.environ.get(_XDG_DATA_HOME):
-        return Path(xdg) / "depo" / "depo.db"
-    return Path.cwd() / "depo.db"
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -39,16 +24,17 @@ class DepoConfig:
     """Immutable application configuration."""
 
     # Paths / Dirs
-    store_root: Path = field(default_factory=_default_store_dir)
-    db_path: Path = field(default_factory=_default_db_path)
+    store_root: Path = field(default_factory=defaults.default_store_dir)
+    db_path: Path = field(default_factory=defaults.default_db_path)
     # Network
-    host: str = "127.0.0.1"
-    port: int = 8765
+    host: str = defaults.HOST
+    port: int = defaults.PORT
     # Limits/thresholds
-    max_size_bytes: int = 10_485_760
-    max_url_len: int = 2048
+    max_size_bytes: int = defaults.MAX_SIZE_BYTES
+    max_url_len: int = defaults.MAX_URL_LEN
+    min_code_len: int = defaults.MIN_CODE_LEN
     # Logging/ErrorHandling
-    log_level: Severity = Severity.WARNING
+    log_level: Severity = defaults.LOG_LEVEL
 
 
 def _xdg_config_home() -> Path:
@@ -67,7 +53,7 @@ def _load_toml(path: Path) -> dict:
 
 def _coerce(overrides: dict) -> dict:
     """Coerce string values from env/TOML to expected types."""
-    int_fields = {"port", "max_size_bytes", "max_url_len"}
+    int_fields = {"port", "max_size_bytes", "max_url_len", "min_code_len"}
     path_fields = {"db_path", "store_root"}
     out = {}
     for k, v in overrides.items():

--- a/src/depo/cli/defaults.py
+++ b/src/depo/cli/defaults.py
@@ -1,0 +1,37 @@
+# src/depo/cli/defaults.py
+"""
+Default value production for DepoConfig.
+Scalar defaults and path-discovery helpers, kept apart from
+config.py's structuring and override-resolution logic.
+Author: Marcus Grant
+Created: 2026-06-04
+License: Apache-2.0
+"""
+
+import os
+from pathlib import Path
+
+from depo.util.errors import Severity
+
+HOST = "127.0.0.1"
+PORT = 8765
+MAX_SIZE_BYTES = 2**26
+MAX_URL_LEN = 2048
+MIN_CODE_LEN = 8
+LOG_LEVEL = Severity.WARNING
+
+_XDG_DATA_HOME = "XDG_DATA_HOME"
+
+
+def default_store_dir() -> Path:
+    """Return XDG_DATA_HOME/depo/store if set, else ./store for containerized deploys"""
+    if xdg := os.environ.get(_XDG_DATA_HOME):
+        return Path(xdg) / "depo" / "store"
+    return Path.cwd() / "store"
+
+
+def default_db_path() -> Path:
+    """Return default database path. XDG_DATA_HOME/depo/depo.db or ./depo.db."""
+    if xdg := os.environ.get(_XDG_DATA_HOME):
+        return Path(xdg) / "depo" / "depo.db"
+    return Path.cwd() / "depo.db"

--- a/src/depo/service/ingest.py
+++ b/src/depo/service/ingest.py
@@ -7,6 +7,7 @@ and metadata extraction into a WritePlan.
 
 Author: Marcus Grant
 Date: 2026-01-23
+Revised: [2026-06-09]
 License: Apache-2.0
 """
 
@@ -33,7 +34,7 @@ class IngestService:
     def __init__(
         self,
         *,
-        min_code_length: int = 8,
+        min_code_len: int,
         max_size_bytes: int = DEFAULT_MAX_SIZE_BYTES,
         max_url_len: int = DEFAULT_MAX_URL_LEN,
     ) -> None:
@@ -43,7 +44,7 @@ class IngestService:
             min_code_length: Minimum short code length.
             max_size_bytes: Maximum allowed upload size.
         """
-        self.min_code_length = min_code_length
+        self.min_code_len = min_code_len
         self.max_size_bytes = max_size_bytes
         self.max_url_len = max_url_len
 
@@ -116,7 +117,7 @@ class IngestService:
         # Assemble final write plan
         return WritePlan(
             hash_full=hash_full_b32(data),
-            code_min_len=self.min_code_length,
+            code_min_len=self.min_code_len,
             payload_kind=payload_kind,
             size_b=size,
             upload_at=int(time.time()),

--- a/src/depo/util/errors.py
+++ b/src/depo/util/errors.py
@@ -6,6 +6,7 @@ Created: 2026-03-10
 License: Apache-2.0
 """
 
+from collections.abc import Iterable
 from enum import IntEnum
 from typing import Literal
 
@@ -25,6 +26,7 @@ class Severity(IntEnum):
 # == Base ==
 
 
+# TODO: Consider adding another base class layer between web and others like config
 class DepoError(Exception):
     """Root exception for all depo errors."""
 
@@ -43,6 +45,40 @@ class DepoError(Exception):
         super().__init__(self.message)
         self.status = status if status is not None else self.__class__.status
         self.ctx = context
+
+
+# == Preflight Domain ==
+
+
+class ConfigError(DepoError):
+    """
+    Configuration resolution or validation failure.
+
+    Raised while building DepoConfig before the app serves any
+    request, so it surfaces at startup or on the CLI, never
+    through an HTTP response; the inherited 500 status is inert.
+    Builds an admin-facing message naming the offending key, its
+    bad value, and the accepted values, so the operator can fix
+    the config from the message alone.
+    """
+
+    severity = Severity.CRITICAL
+
+    def __init__(
+        self,
+        key: str,
+        value: object,
+        expected: Iterable[str] | str | None = None,
+        context: dict | None = None,
+    ) -> None:
+        """Build a config message from the key, bad value, and expected input."""
+        self.key = key
+        self.value = value
+        message = f"Invalid config for '{key}': '{value}'."
+        if expected is not None:
+            choices = expected if isinstance(expected, str) else ", ".join(expected)
+            message += f" Expected: {choices}."
+        super().__init__(message, context)
 
 
 # == Server Domain ==

--- a/src/depo/web/app.py
+++ b/src/depo/web/app.py
@@ -44,7 +44,11 @@ def app_factory(config: DepoConfig) -> FastAPI:
     init_db(conn)  # NOTE: Thread pooling/write queing in repo is not ready yet
     repo = SqliteRepository(conn)
     store = FilesystemStorage(root=app.state.config.store_root)
-    service = IngestService()
+    service = IngestService(
+        min_code_len=app.state.config.min_code_len,
+        max_size_bytes=app.state.config.max_size_bytes,
+        max_url_len=app.state.config.max_url_len,
+    )
 
     # Store server's repo, store & orchestrator instances
     app.state.repo, app.state.store = repo, store

--- a/src/depo/web/app.py
+++ b/src/depo/web/app.py
@@ -21,6 +21,7 @@ from depo.repo.sqlite import SqliteRepository, init_db
 from depo.service.ingest import IngestService
 from depo.service.orchestrator import IngestOrchestrator
 from depo.storage.filesystem import FilesystemStorage
+from depo.util.errors import Severity
 
 
 def app_factory(config: DepoConfig) -> FastAPI:
@@ -67,10 +68,10 @@ def app_factory(config: DepoConfig) -> FastAPI:
     return app  # Return FastAPI app
 
 
-def configure_logging(level: str) -> None:
+def configure_logging(level: Severity) -> None:
     """Set the depo logger to the named level with a text handler"""
     logger = logging.getLogger("depo")
-    logger.setLevel(level.upper())
+    logger.setLevel(level)
     if not any(isinstance(h, logging.StreamHandler) for h in logger.handlers):
         handler = logging.StreamHandler()
         fmt = "%(levelname)s %(name)s: %(message)s"

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -15,13 +15,9 @@ from pathlib import Path
 import pytest
 from tests.helpers.assertions import assert_field
 
-from depo.cli.config import (
-    _XDG_DATA_HOME,
-    DepoConfig,
-    _default_db_path,
-    _default_store_dir,
-    load_config,
-)
+from depo.cli import defaults
+from depo.cli.config import DepoConfig, load_config
+from depo.cli.defaults import _XDG_DATA_HOME, default_db_path, default_store_dir
 from depo.util.errors import ConfigError, Severity
 
 
@@ -47,19 +43,19 @@ class TestDefaultPaths:
 
     def test_store_dir_xdg(self, monkeypatch, tmp_path):
         monkeypatch.setenv(_XDG_DATA_HOME, str(tmp_path))
-        assert _default_store_dir() == tmp_path / "depo" / "store"
+        assert default_store_dir() == tmp_path / "depo" / "store"
 
     def test_store_dir_fallback(self, monkeypatch):
         monkeypatch.delenv(_XDG_DATA_HOME, raising=False)
-        assert _default_store_dir() == Path.cwd() / "store"
+        assert default_store_dir() == Path.cwd() / "store"
 
     def test_db_path_xdg(self, monkeypatch, tmp_path):
         monkeypatch.setenv(_XDG_DATA_HOME, str(tmp_path))
-        assert _default_db_path() == tmp_path / "depo" / "depo.db"
+        assert default_db_path() == tmp_path / "depo" / "depo.db"
 
     def test_db_path_fallback(self, monkeypatch):
         monkeypatch.delenv(_XDG_DATA_HOME, raising=False)
-        assert _default_db_path() == Path.cwd() / "depo.db"
+        assert default_db_path() == Path.cwd() / "depo.db"
 
 
 class TestDepoConfig:
@@ -70,8 +66,9 @@ class TestDepoConfig:
         [
             ("host", str, False, "127.0.0.1"),
             ("port", int, False, 8765),
-            ("max_size_bytes", int, False, 10_485_760),
-            ("max_url_len", int, False, 2048),
+            ("max_size_bytes", int, False, defaults.MAX_SIZE_BYTES),
+            ("max_url_len", int, False, defaults.MAX_URL_LEN),
+            ("min_code_len", int, False, defaults.MIN_CODE_LEN),
             ("log_level", Severity, False, Severity.WARNING),
         ],
     )
@@ -97,8 +94,8 @@ class TestDepoConfig:
         cfg = DepoConfig(host="0.0.0.0", port=3000)
         assert cfg.host == "0.0.0.0"
         assert cfg.port == 3000
-        assert cfg.max_size_bytes == 10_485_760
-        assert cfg.max_url_len == 2048
+        assert cfg.max_size_bytes == defaults.MAX_SIZE_BYTES
+        assert cfg.max_url_len == defaults.MAX_URL_LEN
 
 
 class TestLoadConfigToml:
@@ -113,7 +110,7 @@ class TestLoadConfigToml:
         cfg = load_config()
         assert cfg.host == "0.0.0.0"
         assert cfg.port == 9000
-        assert cfg.max_size_bytes == 10_485_760
+        assert cfg.max_size_bytes == defaults.MAX_SIZE_BYTES
 
     def test_local_toml_overrides_xdg(self, monkeypatch, tmp_path):
         _clear_depo_env(monkeypatch)
@@ -140,7 +137,7 @@ class TestLoadConfigToml:
         cfg = load_config()
         assert cfg.host == "10.0.0.1"
         assert cfg.port == 8765
-        assert cfg.max_url_len == 2048
+        assert cfg.max_url_len == defaults.MAX_URL_LEN
 
     def test_toml_log_level(self, monkeypatch, tmp_path):
         """log_level resolves from a TOML config file."""
@@ -204,8 +201,6 @@ class TestLoadConfigEnv:
 
     def test_env_log_level_case_insensitive(self, monkeypatch, tmp_path):
         """A lowercase DEPO_LOG_LEVEL still resolves to a Severity member."""
-        # same setup as test_env_log_level, DEPO_LOG_LEVEL=debug
-        # assert load_config().log_level == Severity.DEBUG
         self._clear_depo_env(monkeypatch)
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         monkeypatch.chdir(tmp_path)
@@ -214,8 +209,6 @@ class TestLoadConfigEnv:
 
     def test_env_log_level_invalid_raises(self, monkeypatch, tmp_path):
         """An unknown DEPO_LOG_LEVEL raises ConfigError."""
-        # same setup, DEPO_LOG_LEVEL=BANANA
-        # with pytest.raises(ConfigError): load_config()
         self._clear_depo_env(monkeypatch)
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         monkeypatch.chdir(tmp_path)

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -7,6 +7,8 @@ Created: 2026-02-06
 License: Apache-2.0
 """
 
+# TODO: A ton of these can be refactored to use make_config factory
+
 import os
 from pathlib import Path
 
@@ -20,6 +22,7 @@ from depo.cli.config import (
     _default_store_dir,
     load_config,
 )
+from depo.util.errors import ConfigError, Severity
 
 
 def _clear_depo_env(monkeypatch):
@@ -69,7 +72,7 @@ class TestDepoConfig:
             ("port", int, False, 8765),
             ("max_size_bytes", int, False, 10_485_760),
             ("max_url_len", int, False, 2048),
-            ("log_level", str, False, "WARNING"),
+            ("log_level", Severity, False, Severity.WARNING),
         ],
     )
     def test_simple_fields(self, name, typ, required, default):
@@ -145,7 +148,7 @@ class TestLoadConfigToml:
         _write_toml(tmp_path / "xdg/depo/config.toml", log_level="DEBUG")
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
         monkeypatch.chdir(tmp_path)
-        assert load_config().log_level == "DEBUG"
+        assert load_config().log_level == Severity.DEBUG
 
 
 class TestLoadConfigEnv:
@@ -197,7 +200,28 @@ class TestLoadConfigEnv:
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         monkeypatch.chdir(tmp_path)
         monkeypatch.setenv("DEPO_LOG_LEVEL", "DEBUG")
-        assert load_config().log_level == "DEBUG"
+        assert load_config().log_level == Severity.DEBUG
+
+    def test_env_log_level_case_insensitive(self, monkeypatch, tmp_path):
+        """A lowercase DEPO_LOG_LEVEL still resolves to a Severity member."""
+        # same setup as test_env_log_level, DEPO_LOG_LEVEL=debug
+        # assert load_config().log_level == Severity.DEBUG
+        self._clear_depo_env(monkeypatch)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DEPO_LOG_LEVEL", "deBug")
+        assert load_config().log_level == Severity.DEBUG
+
+    def test_env_log_level_invalid_raises(self, monkeypatch, tmp_path):
+        """An unknown DEPO_LOG_LEVEL raises ConfigError."""
+        # same setup, DEPO_LOG_LEVEL=BANANA
+        # with pytest.raises(ConfigError): load_config()
+        self._clear_depo_env(monkeypatch)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DEPO_LOG_LEVEL", "BANANA")
+        with pytest.raises(ConfigError):
+            load_config()
 
 
 class TestLoadConfigFlag:

--- a/tests/cli/test_defaults.py
+++ b/tests/cli/test_defaults.py
@@ -1,0 +1,35 @@
+# tests/cli/test_defaults.py
+"""
+Tests for cli/defaults.py value production.
+Author: Marcus Grant
+Created: 2026-06-04
+License: Apache-2.0
+"""
+
+from pathlib import Path
+
+from depo.cli.defaults import _XDG_DATA_HOME, default_db_path, default_store_dir
+
+
+class TestDefaultPaths:
+    """Tests for path resolution helpers."""
+
+    def test_store_dir_xdg(self, monkeypatch, tmp_path):
+        """XDG_DATA_HOME set yields its depo/store subdir."""
+        monkeypatch.setenv(_XDG_DATA_HOME, str(tmp_path))
+        assert default_store_dir() == tmp_path / "depo" / "store"
+
+    def test_store_dir_fallback(self, monkeypatch):
+        """No XDG_DATA_HOME falls back to ./store."""
+        monkeypatch.delenv(_XDG_DATA_HOME, raising=False)
+        assert default_store_dir() == Path.cwd() / "store"
+
+    def test_db_path_xdg(self, monkeypatch, tmp_path):
+        """XDG_DATA_HOME set yields its depo/depo.db path."""
+        monkeypatch.setenv(_XDG_DATA_HOME, str(tmp_path))
+        assert default_db_path() == tmp_path / "depo" / "depo.db"
+
+    def test_db_path_fallback(self, monkeypatch):
+        """No XDG_DATA_HOME falls back to ./depo.db."""
+        monkeypatch.delenv(_XDG_DATA_HOME, raising=False)
+        assert default_db_path() == Path.cwd() / "depo.db"

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -53,15 +53,16 @@ __all__ = [
 HEADER_HTMX = {"HX-Request": "true"}
 
 
-def make_config(p: Path) -> DepoConfig:
+def make_config(p: Path, **overrides: Any) -> DepoConfig:
     """Build a DepoConfig with db and store paths under p.
-
     Typically called with pytest's tmp_path fixture.
     Creates paths at p/data/depo.db and p/store but does
     not initialize the database or create directories.
+    Keyword overrides replace any default field on the returned config.
     Used internally by make_client.
     """
-    return DepoConfig(db_path=p / "data" / "depo.db", store_root=p / "store")
+    base = {"db_path": p / "data" / "depo.db", "store_root": p / "store"}
+    return DepoConfig(**{**base, **overrides})
 
 
 def make_client(p: Path) -> TestClient:

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -19,9 +19,11 @@ from bs4 import BeautifulSoup as BSoup
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
+from depo.cli import defaults
 from depo.cli.config import DepoConfig
 from depo.model.enums import ContentFormat, ItemKind, Visibility
 from depo.model.item import LinkItem, PicItem, TextItem
+from depo.service.ingest import IngestService
 from depo.service.orchestrator import PersistResult
 from depo.web.app import app_factory
 from depo.web.templates import get_templates
@@ -63,6 +65,17 @@ def make_config(p: Path, **overrides: Any) -> DepoConfig:
     """
     base = {"db_path": p / "data" / "depo.db", "store_root": p / "store"}
     return DepoConfig(**{**base, **overrides})
+
+
+def make_ingest_service(**overrides: int) -> IngestService:
+    """Build an IngestService with default limits, overridable per test."""
+    params: dict[str, int] = {
+        "min_code_length": defaults.MIN_CODE_LEN,
+        "max_size_bytes": defaults.MAX_SIZE_BYTES,
+        "max_url_len": defaults.MAX_URL_LEN,
+    }
+    params.update(overrides)
+    return IngestService(**params)
 
 
 def make_client(p: Path) -> TestClient:

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -70,7 +70,7 @@ def make_config(p: Path, **overrides: Any) -> DepoConfig:
 def make_ingest_service(**overrides: int) -> IngestService:
     """Build an IngestService with default limits, overridable per test."""
     params: dict[str, int] = {
-        "min_code_length": defaults.MIN_CODE_LEN,
+        "min_code_len": defaults.MIN_CODE_LEN,
         "max_size_bytes": defaults.MAX_SIZE_BYTES,
         "max_url_len": defaults.MAX_URL_LEN,
     }

--- a/tests/factories/test_factories.py
+++ b/tests/factories/test_factories.py
@@ -1,0 +1,22 @@
+# tests/factories/test_factories.py
+"""
+Tests for the test factories.
+Exercises the reusable builders in tests/factories,
+starting with make_config keyword overrides.
+Author: Marcus Grant
+Created: 2026-06-04
+License: Apache-2.0
+"""
+
+from pathlib import Path
+
+from tests.factories import make_config
+
+
+class TestMakeConfig:
+    """Tests for the make_config factory."""
+
+    def test_override_reaches_config(self, tmp_path: Path) -> None:
+        """An applied keyword override lands on the returned config."""
+        assert make_config(tmp_path, max_size_bytes=1).max_size_bytes == 1
+        assert make_config(tmp_path, log_level="INFO").log_level == "INFO"

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -20,10 +20,9 @@ from fastapi.testclient import TestClient
 
 from depo.model.item import LinkItem, PicItem, TextItem
 from depo.repo.sqlite import SqliteRepository, init_db
-from depo.service.ingest import IngestService
 from depo.service.orchestrator import IngestOrchestrator
 from depo.storage.filesystem import FilesystemStorage
-from tests.factories import gen_image, make_client
+from tests.factories import gen_image, make_client, make_ingest_service
 from tests.factories.db import insert_link_item, insert_pic_item, insert_text_item
 
 
@@ -82,7 +81,7 @@ def t_orch_env(
     (orchestrator, repo, store) for ingest integration
     tests that need to inspect side effects.
     """
-    service = IngestService()
+    service = make_ingest_service()
     orch = IngestOrchestrator(service, t_repo, t_store)
     return (orch, t_repo, t_store)
 

--- a/tests/service/test_ingest.py
+++ b/tests/service/test_ingest.py
@@ -35,10 +35,10 @@ class TestIngestServiceInit:
     def test_accepts_valid_configs(self, min_len, max_size, max_url):
         """Accepts min_code_length & max_size_bytes as config"""
         result = IngestService(
-            min_code_length=min_len, max_size_bytes=max_size, max_url_len=max_url
+            min_code_len=min_len, max_size_bytes=max_size, max_url_len=max_url
         )
         assert isinstance(result, IngestService)
-        assert result.min_code_length == min_len
+        assert result.min_code_len == min_len
         assert result.max_size_bytes == max_size
         assert result.max_url_len == max_url
 
@@ -220,7 +220,7 @@ class TestIngestServiceAssembly:
 
     def test_writeplan_has_code_min_len_from_config(self):
         """Returns WritePlan with code_min_len from IngestService config."""
-        plan = make_ingest_service(min_code_length=12).build_plan(
+        plan = make_ingest_service(min_code_len=12).build_plan(
             payload_bytes=b"hello",
             requested_format=ContentFormat.PLAINTEXT,
         )

--- a/tests/service/test_ingest.py
+++ b/tests/service/test_ingest.py
@@ -11,7 +11,7 @@ import time
 from pathlib import Path
 
 import pytest
-from tests.factories import gen_image
+from tests.factories import gen_image, make_ingest_service
 
 from depo.model.enums import ContentFormat, ItemKind, PayloadKind
 from depo.service.ingest import IngestService
@@ -48,7 +48,7 @@ class TestIngestServiceValidation:
 
     def test_if_invalid_payload_source(self):
         """Raises PayloadSourceError if neither or both payload_{bytes,path} given."""
-        ingest = IngestService()
+        ingest = make_ingest_service()
         with pytest.raises(PayloadSourceError, match=r"payload_bytes.*payload_path"):
             ingest.build_plan()
         with pytest.raises(PayloadSourceError, match=r"payload_bytes.*payload_path"):
@@ -58,19 +58,19 @@ class TestIngestServiceValidation:
         """Raises PayloadTooLargeError if max_size_bytes is exceeded by payload_path"""
         big_file = tmp_path / "big.txt"
         big_file.write_bytes(b"x" * 1001)
-        ingest = IngestService(max_size_bytes=1000)
+        ingest = make_ingest_service(max_size_bytes=1000)
         with pytest.raises(PayloadTooLargeError, match=r"1001.*1000"):
             ingest.build_plan(payload_path=big_file)
 
     def test_if_payload_bytes_max_size_exceeded(self):
         """Raises PayloadTooLargeError if max_size_bytes is exceeded by payload_bytes"""
-        ingest = IngestService(max_size_bytes=1000)
+        ingest = make_ingest_service(max_size_bytes=1000)
         with pytest.raises(PayloadTooLargeError, match=r"1001.*1000"):
             ingest.build_plan(payload_bytes=(b"\xff" * 1001))
 
     def test_if_payload_empty(self, tmp_path):
         """Raises PayloadEmptyError if max_size_bytes is exceeded by payload_bytes"""
-        ingest = IngestService(max_size_bytes=1000)
+        ingest = make_ingest_service(max_size_bytes=1000)
         empty_file = tmp_path / "empty.txt"
         empty_file.write_bytes(b"")
         with pytest.raises(PayloadEmptyError):
@@ -87,12 +87,16 @@ class TestIngestServiceHashing:
         """Returns WritePlan with hash_full same as hash_full_b32"""
         # With bytes
         kwargs = {"payload_bytes": data, "requested_format": ContentFormat.PLAINTEXT}
-        assert IngestService().build_plan(**kwargs).hash_full == hash_full_b32(data)
+        assert make_ingest_service().build_plan(**kwargs).hash_full == hash_full_b32(
+            data
+        )
         # With file
         f = tmp_path / "file.txt"
         f.write_bytes(data)
         kwargs = {"payload_path": f, "requested_format": ContentFormat.PLAINTEXT}
-        assert IngestService().build_plan(**kwargs).hash_full == hash_full_b32(data)
+        assert make_ingest_service().build_plan(**kwargs).hash_full == hash_full_b32(
+            data
+        )
 
 
 class TestIngestServiceClassify:
@@ -101,7 +105,7 @@ class TestIngestServiceClassify:
     def test_writeplan_has_kind_and_format_from_classify(self):
         """Returns WritePlan with kind and format from classify."""
         # requested_format bypasses content inspection
-        plan = IngestService().build_plan(
+        plan = make_ingest_service().build_plan(
             payload_bytes=b"anything",
             requested_format=ContentFormat.MARKDOWN,
         )
@@ -110,7 +114,7 @@ class TestIngestServiceClassify:
 
     def test_classify_uses_filename_hint(self):
         """Passes filename to classify for extension-based detection."""
-        plan = IngestService().build_plan(
+        plan = make_ingest_service().build_plan(
             payload_bytes=b"no magic bytes here",
             filename="notes.json",
         )
@@ -118,7 +122,7 @@ class TestIngestServiceClassify:
 
     def test_classify_uses_declared_mime_hint(self):
         """Passes declared_mime to classify."""
-        plan = IngestService().build_plan(
+        plan = make_ingest_service().build_plan(
             payload_bytes=b"no magic bytes here",
             declared_mime="application/yaml",
         )
@@ -127,14 +131,18 @@ class TestIngestServiceClassify:
     def test_raises_if_classify_fails(self):
         """Raises ValueError if content cannot be classified."""
         with pytest.raises(ClassificationError, match=r"(?i)(classify|unsupport)"):
-            IngestService().build_plan(payload_bytes=b"\xff\xfe\xfd", filename="no-ext")
+            make_ingest_service().build_plan(
+                payload_bytes=b"\xff\xfe\xfd", filename="no-ext"
+            )
 
 
 class TestIngestServiceImage:
     """Tests IngestService.build_plan image medatata integration"""
 
     def test_writeplan_with_image_info_for_pic_kind(self):
-        plan = IngestService().build_plan(payload_bytes=gen_image("PNG", 320, 240))
+        plan = make_ingest_service().build_plan(
+            payload_bytes=gen_image("PNG", 320, 240)
+        )
         assert plan.kind == ItemKind.PICTURE
         assert plan.format == ContentFormat.PNG
         assert plan.width == 320
@@ -143,8 +151,8 @@ class TestIngestServiceImage:
     def test_writeplan_without_image_info_for_text_kind(self):
         """Returns WritePlan without width, or height for non ItemKind.PICTURE"""
         kwargs = {"payload_bytes": b"\x00", "requested_format": ContentFormat.PLAINTEXT}
-        assert IngestService().build_plan(**kwargs).width is None
-        assert IngestService().build_plan(**kwargs).height is None
+        assert make_ingest_service().build_plan(**kwargs).width is None
+        assert make_ingest_service().build_plan(**kwargs).height is None
 
     def test_raises_if_image_data_corrupt(self):
         """Raises ValueError if image metadata extraction fails"""
@@ -152,7 +160,7 @@ class TestIngestServiceImage:
         with pytest.raises(
             ImageDecodeError
         ):  # Prefer JPEGEXIF magic bytes, expect EXIF
-            IngestService().build_plan(payload_bytes=b"\xff\xd8\xff\xe1")
+            make_ingest_service().build_plan(payload_bytes=b"\xff\xd8\xff\xe1")
 
 
 class TestIngestServiceLink:
@@ -160,7 +168,7 @@ class TestIngestServiceLink:
 
     def test_writeplan_fields_for_url_payload(self):
         """URL payload_bytes classes as LINK with BYTES payload_kind & right hash"""
-        plan = IngestService().build_plan(payload_bytes=b"http://a.eu")
+        plan = make_ingest_service().build_plan(payload_bytes=b"http://a.eu")
         assert plan.kind == ItemKind.LINK
         assert plan.payload_kind == PayloadKind.BYTES
         assert plan.hash_full == hash_full_b32(bytes("http://a.eu", encoding="utf-8"))
@@ -168,7 +176,7 @@ class TestIngestServiceLink:
     def test_raises_if_url_exceeds_max_url_len(self):
         """Raises PayloadTooLargeError if classified URL payload exceeds max_url_len."""
         with pytest.raises(PayloadTooLargeError, match=r"URL.*11.*4"):
-            IngestService(max_url_len=4).build_plan(payload_bytes=b"http://a.eu")
+            make_ingest_service(max_url_len=4).build_plan(payload_bytes=b"http://a.eu")
 
 
 class TestIngestServiceAssembly:
@@ -176,7 +184,7 @@ class TestIngestServiceAssembly:
 
     def test_writeplan_has_payload_kind_bytes(self):
         """Returns WritePlan with payload_kind=BYTES for payload_bytes input."""
-        plan = IngestService().build_plan(
+        plan = make_ingest_service().build_plan(
             payload_bytes=b"hello",
             requested_format=ContentFormat.PLAINTEXT,
         )
@@ -186,7 +194,7 @@ class TestIngestServiceAssembly:
         """Returns WritePlan with payload_kind=FILE for payload_path input."""
         f = tmp_path / "test.txt"
         f.write_bytes(b"hello")
-        plan = IngestService().build_plan(
+        plan = make_ingest_service().build_plan(
             payload_path=f,
             requested_format=ContentFormat.PLAINTEXT,
         )
@@ -194,7 +202,7 @@ class TestIngestServiceAssembly:
 
     def test_writeplan_has_size_b(self):
         """Returns WritePlan with size_b from len(data)."""
-        plan = IngestService().build_plan(
+        plan = make_ingest_service().build_plan(
             payload_bytes=b"Hello, World!",
             requested_format=ContentFormat.PLAINTEXT,
         )
@@ -203,7 +211,7 @@ class TestIngestServiceAssembly:
     def test_writeplan_has_upload_at(self):
         """Returns WritePlan with upload_at as current timestamp."""
         before = int(time.time())
-        plan = IngestService().build_plan(
+        plan = make_ingest_service().build_plan(
             payload_bytes=b"hello",
             requested_format=ContentFormat.PLAINTEXT,
         )
@@ -212,7 +220,7 @@ class TestIngestServiceAssembly:
 
     def test_writeplan_has_code_min_len_from_config(self):
         """Returns WritePlan with code_min_len from IngestService config."""
-        plan = IngestService(min_code_length=12).build_plan(
+        plan = make_ingest_service(min_code_length=12).build_plan(
             payload_bytes=b"hello",
             requested_format=ContentFormat.PLAINTEXT,
         )
@@ -222,7 +230,7 @@ class TestIngestServiceAssembly:
     def test_writeplan_has_payload_bytes_from_bytes(self):
         """WritePlan.payload_bytes populated from payload_bytes input."""
         data = b"hello world"
-        plan = IngestService().build_plan(
+        plan = make_ingest_service().build_plan(
             payload_bytes=data,
             requested_format=ContentFormat.PLAINTEXT,
         )
@@ -233,7 +241,7 @@ class TestIngestServiceAssembly:
         f = tmp_path / "test.txt"
         data = b"hello world"
         f.write_bytes(data)
-        plan = IngestService().build_plan(
+        plan = make_ingest_service().build_plan(
             payload_path=f,
             requested_format=ContentFormat.PLAINTEXT,
         )

--- a/tests/service/test_orchestrator.py
+++ b/tests/service/test_orchestrator.py
@@ -10,13 +10,13 @@ License: Apache-2.0
 from dataclasses import FrozenInstanceError
 
 import pytest
+from tests.factories import make_ingest_service
 from tests.factories.models import make_link_item, make_pic_item, make_text_item
 from tests.factories.payloads import gen_image
 from tests.helpers.assertions import assert_field
 
 from depo.model.enums import ContentFormat
 from depo.model.item import LinkItem, PicItem, TextItem
-from depo.service.ingest import IngestService
 from depo.service.orchestrator import IngestOrchestrator, PersistResult
 from depo.util.shortcode import hash_full_b32
 
@@ -61,7 +61,7 @@ class TestIngestOrchestratorInit:
 
     def test_stores_all_members(self, t_repo, t_store):
         """Stores IngestOrchestrator expected members"""
-        service = IngestService()
+        service = make_ingest_service()
         orchestrator = IngestOrchestrator(service, t_repo, t_store)
         assert orchestrator._service is service
         assert orchestrator._repo is t_repo

--- a/tests/util/test_errors.py
+++ b/tests/util/test_errors.py
@@ -25,6 +25,7 @@ class TestErrorSeverity:
     """Severity resolution across the concrete error hierarchy (gap test)."""
 
     EXPECTED = {
+        errors.ConfigError: errors.Severity.CRITICAL,
         errors.ServerError: errors.Severity.ERROR,
         errors.UnknownServerError: errors.Severity.ERROR,
         errors.MissingDependencyError: errors.Severity.WARNING,
@@ -82,6 +83,46 @@ class TestDepoError:
         """DepoError defaults severity to ERROR and exception to None."""
         assert errors.DepoError.severity == errors.Severity.ERROR
         assert errors.DepoError.exception is None
+
+
+# == Preflight Domain ==
+
+
+class TestConfigError:
+    """Tests for ConfigError."""
+
+    def _default_err(self):
+        """Alias helper for default test ConfigError instance."""
+        return errors.ConfigError("key", "value", "expect", {"foo": "bar"})
+
+    def test_is_depo_error(self) -> None:
+        """ConfigError is a DepoError subclass."""
+        assert isinstance(self._default_err(), errors.DepoError)
+
+    def test_severity_is_critical(self) -> None:
+        """ConfigError reports CRITICAL severity."""
+        assert self._default_err().severity == errors.Severity.CRITICAL
+
+    def test_status_inherits_500(self) -> None:
+        """ConfigError carries the inherited, inert 500 status."""
+        assert self._default_err().status == 500
+
+    def test_stashes_key_and_value(self) -> None:
+        """The offending key and value are kept on the instance."""
+        assert errors.ConfigError("log_level", "BANANA").key == "log_level"
+        assert errors.ConfigError("log_level", "BANANA").value == "BANANA"
+
+    def test_message_names_key_and_value(self) -> None:
+        """With no expected set, the message names just key and value."""
+        msg = errors.ConfigError("log_level", "BANANA").message
+        assert msg == "Invalid config for 'log_level': 'BANANA'."
+
+    def test_message_lists_expected(self) -> None:
+        """Given expected values, the message appends them."""
+        assert (
+            errors.ConfigError("log_level", "BANANA", ["DEBUG", "WARNING"]).message
+            == "Invalid config for 'log_level': 'BANANA'. Expected: DEBUG, WARNING."
+        )
 
 
 # == Server Domain ==

--- a/tests/web/test_app.py
+++ b/tests/web/test_app.py
@@ -7,7 +7,6 @@ Created: 2026-02-09
 License: Apache-2.0
 """
 
-import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -39,7 +38,6 @@ class TestHealthCheck:
         assert resp.text == "ok"
 
 
-@pytest.mark.skip(reason="config not yet wired into IngestService")
 class TestConfigWiring:
     """Resolved config governs the live upload path (gating tests)."""
 
@@ -55,8 +53,8 @@ class TestConfigWiring:
         resp = client.post("/upload?url=http://example.com")
         assert resp.status_code == 413
 
-    def test_min_code_length_governs(self, tmp_path):
+    def test_min_code_len_governs(self, tmp_path):
         """A raised min_code_length yields a code of exactly that length."""
-        client = TestClient(app_factory(make_config(tmp_path, min_code_length=12)))
+        client = TestClient(app_factory(make_config(tmp_path, min_code_len=12)))
         resp = client.post("/upload", files={"file": ("t.txt", b"hello world")})
         assert len(resp.headers["X-Depo-Code"]) == 12

--- a/tests/web/test_app.py
+++ b/tests/web/test_app.py
@@ -7,7 +7,9 @@ Created: 2026-02-09
 License: Apache-2.0
 """
 
+import pytest
 from fastapi import FastAPI
+from fastapi.testclient import TestClient
 
 from depo.web.app import app_factory
 from tests.factories import make_config
@@ -35,3 +37,26 @@ class TestHealthCheck:
         assert resp.status_code == 200
         assert resp.headers["content-type"].startswith("text/plain")
         assert resp.text == "ok"
+
+
+@pytest.mark.skip(reason="config not yet wired into IngestService")
+class TestConfigWiring:
+    """Resolved config governs the live upload path (gating tests)."""
+
+    def test_max_size_bytes_governs(self, tmp_path):
+        """A tiny max_size_bytes rejects any upload with 413."""
+        client = TestClient(app_factory(make_config(tmp_path, max_size_bytes=1)))
+        resp = client.post("/upload", files={"file": ("t.txt", b"too big")})
+        assert resp.status_code == 413
+
+    def test_max_url_len_governs(self, tmp_path):
+        """A tiny max_url_len rejects a link with 413."""
+        client = TestClient(app_factory(make_config(tmp_path, max_url_len=1)))
+        resp = client.post("/upload?url=http://example.com")
+        assert resp.status_code == 413
+
+    def test_min_code_length_governs(self, tmp_path):
+        """A raised min_code_length yields a code of exactly that length."""
+        client = TestClient(app_factory(make_config(tmp_path, min_code_length=12)))
+        resp = client.post("/upload", files={"file": ("t.txt", b"hello world")})
+        assert len(resp.headers["X-Depo-Code"]) == 12


### PR DESCRIPTION
Extracts default value production into cli/defaults.py, wires resolved config into IngestService, and closes the gaps in config validation.

Changes:
- add cli/defaults.py with scalar constants and path helpers
- source all DepoConfig fields from defaults namespace
- bump max_size_bytes default to 64 MiB (2**26)
- add min_code_len field to DepoConfig
- add ConfigError under a new Preflight Domain in errors.py
- validate and coerce log_level to Severity in _coerce
- make IngestService limits required, wire from app.state.config
- add make_ingest_service factory, migrate test call sites
- add **overrides to make_config factory
- sync cli.md and service.md with landed changes
- record two post-MVP deferrals in unplanned.md