### PR TITLE
Fix: Non-HTMX form fallback error surface

### DIFF
--- a/doc/design/errors.md
+++ b/doc/design/errors.md
@@ -116,13 +116,8 @@ Propagation stays on so test capture and parent handlers still see records.
 
 ## Deferred
 
-Browser error templates for the non-404 4xx codes (400, 409, 413, 422)
-
-The non-HTMX form fallback in `hx_upload`'s dispatcher has no `except DepoError`.
-Expected domain errors on that path currently reach the boundary and
-badly classify as 500 instead of their true 4xx status.
-Needs first-class error handling, tracked in planning.
-
-Remaining error-handling work is tracked in planning:
-structured logging observability in `v0.2`,
-`StorageError` and `FormatMismatchError` in unplanned.
+Remaining error-handling work is tracked in planning: structured logging
+observability in `v0.2`, `StorageError` and `FormatMismatchError` in
+unplanned. `FormatMismatchError` is unrelated to unsupported-token coercion
+(landed in `fix/form-error-surface`); it concerns declared-vs-inferred
+format conflicts post-classification.

--- a/doc/planning/mvp.md
+++ b/doc/planning/mvp.md
@@ -30,102 +30,6 @@ service, repo, and storage. Dedupe by content hash.
 
 Ordered by dependency. Each heading is roughly one PR.
 
-### Non-HTMX form fallback error surface (Branch: `fix/form-error-surface`)
-
-*Problem: the `application/x-www-form-urlencoded` fallback branch in the
-upload dispatcher (`web/routes/upload.py`) runs `_parse_form_upload` and
-`orch.ingest` with no `except DepoError`, so expected domain errors (empty,
-oversized, bad format) on a non-HTMX form POST escape to the boundary, which
-wraps them as `UnknownServerError` and renders a 500. This mislabels ordinary
-4xx as server errors and discards their true status and message. Compounding
-it, a bad `format=` token raises a raw `ValueError` from `ContentFormat(fmt)`
-at three sites (form parse file branch, form parse text branch, and
-`api_upload`), which escapes even a bare `except DepoError`. Decision: the
-form path renders full-page `browser_error` at the error's true status; the
-success 303 redirect to `/{code}/info` is unchanged. Coercion is normalized
-through `format_for_extension` (alias-tolerant, returns None on unknown), with
-the web layer raising `UnsupportedFormatError` on None so the model layer stays
-free of web-error semantics. Out of scope: redirect-with-flash (no flash or
-session infrastructure exists, not introducing it); FormatMismatchError
-(unplanned, unrelated to unsupported-token coercion); the htmx and api error
-surfaces (already wired and tested).*
-
-#### Setup and gating test
-
-- [ ] Branch `fix/form-error-surface` from main.
-- [ ] Add a skipped integration test to `tests/web/routes/test_upload.py`
-      (new `TestFormFallbackError` class) asserting the end state: a non-HTMX
-      form POST (`t_client.post`, `data=...`, no `HEADER_HTMX`) that triggers
-      a domain error renders full-page HTML at the error's true 4xx status,
-      not 500 and not plaintext. Assert `status_code == 400` for an empty
-      submission (PayloadEmptyError is 400), `text/html` content-type, and the
-      `errors/page.html` marker in the body via BeautifulSoup.
-      `@pytest.mark.skip` until the last unit.
-  - [ ] Commit: `Tst: Add skipped gating test for form fallback error surface`
-
-#### TDD implementation
-
-**Normalize format-token coercion through `format_for_extension`**
-(`tests/web/routes/test_upload.py`)
-
-- [ ] Red: add a parse-unit test to `TestParseFormUpload` asserting a bad
-      `format` token on non-empty content raises `UnsupportedFormatError`
-      (use `_test_fn("hello", "bogus")`; non-empty content avoids the
-      `PayloadEmptyError` short-circuit).
-- [ ] Replace the three `ContentFormat(fmt)` call sites in `upload.py`
-      (`_parse_form_upload` file branch, text branch, and `api_upload`'s
-      `req_fmt`) with `format_for_extension(...)`, raising
-      `UnsupportedFormatError(fmt)` when it returns None. Import
-      `format_for_extension` and `UnsupportedFormatError`.
-- [ ] Confirm `test_request_format_for_select_option` stays green
-      (refactor-under-green: canonical tokens still resolve, so the existing
-      assertion is the regression guard for the swap).
-- [ ] uv run ruff check && uv run pytest
-- [ ] Commit: `Fix: Normalize format-token coercion, raise UnsupportedFormatError`
-
-**Surface bad API-path format token as 422**
-(`tests/web/routes/test_upload.py`)
-
-- [ ] Red: add a test under `TestApiUploadError` asserting `?format=bogus`
-      returns 422, mirroring `test_oversized_returns_413`. The coercion swap
-      from the prior unit already routes this through `api_upload`'s existing
-      `except DepoError`, so this asserts the now-correct API surface
-      end to end.
-- [ ] uv run ruff check && uv run pytest
-- [ ] Commit: `Tst: Assert API-path bad format token returns 422`
-
-**Wire form fallback branch to `browser_error`**
-(`tests/web/routes/test_upload.py`)
-
-- [ ] Red: add form-branch tests (`TestFormFallbackError`) asserting an
-      oversized non-HTMX form POST renders full-page HTML at 413, and a
-      bad-format one at 422 (full surface, distinct from the empty-content
-      400 the gating test covers).
-- [ ] In `upload.py`, wrap the form fallback branch's `_parse_form_upload` and
-      `orch.ingest` in `try/except DepoError as e: return browser_error(req, e)`.
-      Import `browser_error`. Catch `DepoError` broadly; `e.status` drives the
-      response. Leave the 303 success path unchanged.
-- [ ] uv run ruff check && uv run pytest
-- [ ] Commit: `Fix: Render browser_error on non-HTMX form fallback DepoError`
-
-#### Integration and documentation
-
-- [ ] Unskip the `TestFormFallbackError` gating test; confirm it passes.
-- [ ] Update `doc/design/errors.md` Deferred section: remove the
-      form-fallback entry (closed by this PR) and mark the non-404 4xx
-      browser-template entry resolved (the error rearchitecture made
-      `errors/page.html` render any status generically; the note drifted
-      out of sync and was never updated).
-- [ ] Note in errors.md that `FormatMismatchError` (unplanned) is unrelated
-      and untouched, to prevent a future reader conflating it with the
-      unsupported-token coercion landed here.
-- [ ] uv run ruff check && uv run pytest
-- [ ] Commit: `Doc: ...`
-
-#### PR
-
-- [ ] gh pr create --title "Fix: Non-HTMX form fallback error surface" --body "..."
-
 ### Users table and model (Branch: `ft/users-table`)
 
 *Problem: there is no user identity in the system. `items.uid` is an
@@ -475,12 +379,8 @@ with the default `uid=0`. The MVP-critical requirement is that no
 anonymous POST is ever possible. Add a web-layer `require_auth`
 dependency that gates both `/upload` routes, a 401 `AuthRequiredError`,
 and thread the authenticated uid into the existing ingest path so items
-persist with the real uploader's id instead of 0. Branch from
-`ft/login-session`. PRECONDITION: this branches only AFTER
-`fix/form-error-surface` has merged (auth adds an unauthenticated path
-to the same upload dispatcher and relies on that dispatcher's error
-surfaces being correct); confirm it has landed before branching. Out of
-scope: `perm`/visibility enforcement and any 403/ownership checks
+persist with the real uploader's id instead of 0. Branch from `ft/login-session`.
+Out of scope: `perm`/visibility enforcement and any 403/ownership checks
 (post-MVP, the column is present and ingest already passes the PUBLIC
 default); roles and user relations (post-MVP); per-item ownership on
 read/delete (post-MVP); CSRF (v1, tracked); rate limiting (post-MVP);
@@ -504,10 +404,8 @@ but splits the gate's behavior by surface), or (c) `AuthRequiredError`
 carries a redirect target and the builders gain a generic
 redirect-instead-of-render rule (reusable, larger builder-contract change).
 The require_auth unit below is written assuming (a)/(c) (it raises); if (b)
-is chosen, that unit changes to return-redirect-for-browser-context. All
-three interact with `fix/form-error-surface`, which reshapes the same
-builders, so confirm that branch's final builder shape before implementing
-either the require_auth or the gate units.*
+is chosen, that unit changes to return-redirect-for-browser-context.
+`fix/form-error-surface` has landed; the builder shape is settled.
 
 Mechanics note on (b): a FastAPI `Depends` cannot short-circuit by
 returning a `Response`; a returned value only populates the parameter.
@@ -517,8 +415,7 @@ collapses it toward (c). Pick (b) only with that understanding.
 
 #### Setup and gating test
 
-- [ ] Confirm `fix/form-error-surface` has merged; branch
-      `ft/upload-gate` from `ft/login-session`.
+- [ ] Branch `ft/upload-gate` from `ft/login-session`.
 - [ ] Add a skipped integration test to `tests/web/test_routes.py` (new
       `TestUploadGate` class) asserting the MVP guarantee end to end: an
       unauthenticated POST `/upload` is rejected and creates no item; an

--- a/src/depo/service/ingest.py
+++ b/src/depo/service/ingest.py
@@ -14,15 +14,13 @@ License: Apache-2.0
 import time
 from pathlib import Path
 
+from depo.cli import defaults
 from depo.model.enums import ContentFormat, ItemKind, PayloadKind
 from depo.model.write_plan import WritePlan
 from depo.service.classify import classify
 from depo.service.media import get_image_info
 from depo.util.errors import PayloadEmptyError, PayloadSourceError, PayloadTooLargeError
 from depo.util.shortcode import hash_full_b32
-
-DEFAULT_MAX_SIZE_BYTES = 2**26  # 64 MiB
-DEFAULT_MAX_URL_LEN = 2048
 
 
 # TODO: Create config loader infrastructure and centralized defaults
@@ -35,8 +33,8 @@ class IngestService:
         self,
         *,
         min_code_len: int,
-        max_size_bytes: int = DEFAULT_MAX_SIZE_BYTES,
-        max_url_len: int = DEFAULT_MAX_URL_LEN,
+        max_size_bytes: int = defaults.MAX_SIZE_BYTES,
+        max_url_len: int = defaults.MAX_URL_LEN,
     ) -> None:
         """Initialize with configuration.
 

--- a/src/depo/web/routes/upload.py
+++ b/src/depo/web/routes/upload.py
@@ -22,7 +22,7 @@ from depo.model.item import LinkItem
 from depo.service.orchestrator import IngestOrchestrator, PersistResult
 from depo.util import errors
 from depo.web.deps import get_orchestrator
-from depo.web.error import api_error, htmx_error
+from depo.web.error import api_error, browser_error, htmx_error
 from depo.web.templates import get_templates, is_htmx
 
 upload_router = APIRouter()
@@ -44,15 +44,15 @@ async def upload(
 ) -> Response:
     """Dispatcher for uploads by content negotiation.
     Delegates to hx_upload for HTMX requests, api_upload for API requests."""
+    url_encoded_head = "application/x-www-form-urlencoded"
     if is_htmx(req):
         return await hx_upload(req, orch)
-    # TODO: bare form fallback — no error handling, no template response.
-    # Proper non-HTMX form POST handling deferred to error handling PR.
-    if req.headers.get("content-type", "").startswith(
-        "application/x-www-form-urlencoded"
-    ):
-        params = await _parse_form_upload(req)
-        result = orch.ingest(**dict(params))  # type: ignore
+    if req.headers.get("content-type", "").startswith(url_encoded_head):
+        try:
+            params = await _parse_form_upload(req)
+            result = orch.ingest(**dict(params))  # type: ignore
+        except errors.DepoError as e:
+            return browser_error(req, e)
         return RedirectResponse(f"/{result.item.code}/info", status_code=303)
     return await api_upload(req, orch=orch, url=url, file=file, fmt=fmt)
 

--- a/src/depo/web/routes/upload.py
+++ b/src/depo/web/routes/upload.py
@@ -17,13 +17,10 @@ from fastapi.responses import PlainTextResponse, RedirectResponse
 from starlette.datastructures import UploadFile as StarletteUploadFile
 
 from depo.model.enums import ContentFormat
+from depo.model.formats import format_for_extension
 from depo.model.item import LinkItem
 from depo.service.orchestrator import IngestOrchestrator, PersistResult
-from depo.util.errors import (
-    DepoError,
-    PayloadEmptyError,
-    PayloadSourceError,
-)
+from depo.util import errors
 from depo.web.deps import get_orchestrator
 from depo.web.error import api_error, htmx_error
 from depo.web.templates import get_templates, is_htmx
@@ -74,7 +71,7 @@ async def hx_upload(
             status_code=200,
             context={"code": result.item.code, "created": result.created},
         )
-    except DepoError as e:
+    except errors.DepoError as e:
         return htmx_error(request, e)
 
 
@@ -86,11 +83,16 @@ async def api_upload(
     fmt: str | None = Query(None, alias="format"),
 ) -> PlainTextResponse:
     """API upload: multipart, raw body, or URL param."""
-    req_fmt_str = fmt or req.headers.get("x-depo-format")
-    req_fmt = ContentFormat(req_fmt_str) if req_fmt_str else None
     try:
+        req_fmt_str = fmt or req.headers.get("x-depo-format")
+        if req_fmt_str:
+            req_fmt = format_for_extension(req_fmt_str)
+            if req_fmt is None:
+                raise errors.UnsupportedFormatError(req_fmt_str)
+        else:
+            req_fmt = None
         result = await _ingest_upload(file, url, req, orch, req_fmt=req_fmt)
-    except DepoError as e:
+    except errors.DepoError as e:
         return api_error(e)
     return _upload_response(result)
 
@@ -139,7 +141,7 @@ async def _parse_upload(
     if url is not None:
         kwargs = {"payload_bytes": url.encode("utf-8"), "declared_mime": None}
         return UploadRawBodyParams(**kwargs)
-    raise PayloadSourceError(sources=["file", "url", "request"])
+    raise errors.PayloadSourceError(sources=["file", "url", "request"])
 
 
 async def _parse_form_upload(
@@ -150,20 +152,27 @@ async def _parse_form_upload(
     content = str(form.get("content", "")).strip()
     file = form.get("file")
     fmt = str(form.get("format", ""))
+    if fmt:
+        _resolved = format_for_extension(fmt)
+        if _resolved is None:
+            raise errors.UnsupportedFormatError(fmt)
+        requested_format: ContentFormat | None = _resolved
+    else:
+        requested_format = None
     if isinstance(file, StarletteUploadFile) and (data := await file.read()):
         return UploadFormParams(
             payload_bytes=data,
             declared_mime=file.content_type or "application/octet-stream",
             filename=file.filename,
-            requested_format=ContentFormat(fmt) if fmt else None,
+            requested_format=requested_format,
         )
     if not content:
-        raise PayloadEmptyError
+        raise errors.PayloadEmptyError
     return UploadFormParams(
         payload_bytes=content.encode("utf-8"),
         declared_mime="text/plain",
         filename=None,
-        requested_format=ContentFormat(fmt) if fmt else None,
+        requested_format=requested_format,
     )
 
 

--- a/tests/web/routes/test_upload.py
+++ b/tests/web/routes/test_upload.py
@@ -282,9 +282,6 @@ class TestApiUploadError:
         assert resp.status_code == 422
 
 
-@pytest.mark.skip(
-    reason="Wired in: Fix: Render browser_error on non-HTMX form fallback DepoError"
-)
 class TestFormFallbackError:
     """Non-HTMX form POST renders full-page browser_error on domain errors."""
 
@@ -292,6 +289,21 @@ class TestFormFallbackError:
         """Empty non-HTMX form POST renders full-page HTML error at 400."""
         resp = t_client.post("/upload", data={"content": "", "format": ""})
         assert resp.status_code == 400
+        assert "text/html" in resp.headers["content-type"]
+        assert "BEGIN: errors/page.html#content" in resp.text
+
+    def test_oversized_renders_page_error(self, t_client):
+        """Oversized non-HTMX form POST renders full-page HTML error at 413."""
+        payload = "x" * (defaults.MAX_SIZE_BYTES + 1)
+        resp = t_client.post("/upload", data={"content": payload, "format": ""})
+        assert resp.status_code == 413
+        assert "text/html" in resp.headers["content-type"]
+        assert "BEGIN: errors/page.html#content" in resp.text
+
+    def test_bad_format_renders_page_error(self, t_client):
+        """Bad format token on nonHTMX form POST renders fullpage HTML error @ 422"""
+        resp = t_client.post("/upload", data={"content": "hello", "format": "bogus"})
+        assert resp.status_code == 422
         assert "text/html" in resp.headers["content-type"]
         assert "BEGIN: errors/page.html#content" in resp.text
 

--- a/tests/web/routes/test_upload.py
+++ b/tests/web/routes/test_upload.py
@@ -5,6 +5,7 @@ Covers POST /upload dispatch, GET /upload page render,
 HTMX partial responses, API uploads, and request parsing.
 Author: Marcus Grant
 Created: 2026-02-23
+Revised: [2026-06-09]
 License: Apache-2.0
 """
 
@@ -18,7 +19,11 @@ from starlette.datastructures import Headers
 
 from depo.model.enums import ContentFormat
 from depo.model.formats import ItemKind
-from depo.util.errors import PayloadEmptyError, PayloadSourceError
+from depo.util.errors import (
+    PayloadEmptyError,
+    PayloadSourceError,
+    UnsupportedFormatError,
+)
 from depo.util.shortcode import _CROCKFORD32
 from depo.web.routes.upload import _parse_form_upload, _parse_upload, _upload_response
 from tests.factories import HEADER_HTMX, gen_image, make_persist_result
@@ -380,6 +385,11 @@ class TestParseFormUpload:
         assert (await self._test_fn("hello", ""))["requested_format"] is None
         assert (await self._test_fn("hello", "txt"))["requested_format"] == cf_txt
         assert (await self._test_fn("hello", "md"))["requested_format"] == cf_md
+
+    async def test_bad_format_token_raises(self):
+        """A bad format token on non-empty content raises UnsupportedFormatError."""
+        with pytest.raises(UnsupportedFormatError):
+            await self._test_fn("hello", "bogus")
 
     async def test_declared_mime_is_plaintext(self):
         """Form content always declares text/plain mime."""

--- a/tests/web/routes/test_upload.py
+++ b/tests/web/routes/test_upload.py
@@ -277,6 +277,20 @@ class TestApiUploadError:
         assert resp.status_code == 413
 
 
+@pytest.mark.skip(
+    reason="Wired in: Fix: Render browser_error on non-HTMX form fallback DepoError"
+)
+class TestFormFallbackError:
+    """Non-HTMX form POST renders full-page browser_error on domain errors."""
+
+    def test_empty_content_renders_page_error(self, t_client):
+        """Empty non-HTMX form POST renders full-page HTML error at 400."""
+        resp = t_client.post("/upload", data={"content": "", "format": ""})
+        assert resp.status_code == 400
+        assert "text/html" in resp.headers["content-type"]
+        assert "BEGIN: errors/page.html#content" in resp.text
+
+
 class TestParseUpload:
     """Tests for parse_upload()."""
 

--- a/tests/web/routes/test_upload.py
+++ b/tests/web/routes/test_upload.py
@@ -17,13 +17,10 @@ from bs4 import BeautifulSoup
 from fastapi import UploadFile
 from starlette.datastructures import Headers
 
+from depo.cli import defaults
 from depo.model.enums import ContentFormat
 from depo.model.formats import ItemKind
-from depo.util.errors import (
-    PayloadEmptyError,
-    PayloadSourceError,
-    UnsupportedFormatError,
-)
+from depo.util import errors
 from depo.util.shortcode import _CROCKFORD32
 from depo.web.routes.upload import _parse_form_upload, _parse_upload, _upload_response
 from tests.factories import HEADER_HTMX, gen_image, make_persist_result
@@ -275,11 +272,14 @@ class TestApiUploadError:
 
     def test_oversized_returns_413(self, t_client):
         """API upload exceeding max size returns 413."""
-        from depo.service.ingest import DEFAULT_MAX_SIZE_BYTES
-
-        payload = b"x" * (DEFAULT_MAX_SIZE_BYTES + 1)
+        payload = b"x" * (defaults.MAX_SIZE_BYTES + 1)
         resp = t_client.post("/upload", files={"file": ("big.txt", payload)})
         assert resp.status_code == 413
+
+    def test_bad_format_token_returns_422(self, t_client):
+        """API upload with unknown format token returns 422."""
+        resp = t_client.post("/upload", content=b"hello", params={"format": "???"})
+        assert resp.status_code == 422
 
 
 @pytest.mark.skip(
@@ -333,7 +333,7 @@ class TestParseUpload:
     @pytest.mark.asyncio
     async def test_no_input_raises(self):
         """No file, no url, no body raises ValueError."""
-        with pytest.raises(PayloadSourceError, match="file.*url.*request"):
+        with pytest.raises(errors.PayloadSourceError, match="file.*url.*request"):
             await _parse_upload(file=None, url=None, request=None)
 
     def test_missing_dependency_returns_error(self, t_htmx, monkeypatch):
@@ -388,7 +388,7 @@ class TestParseFormUpload:
 
     async def test_bad_format_token_raises(self):
         """A bad format token on non-empty content raises UnsupportedFormatError."""
-        with pytest.raises(UnsupportedFormatError):
+        with pytest.raises(errors.UnsupportedFormatError):
             await self._test_fn("hello", "bogus")
 
     async def test_declared_mime_is_plaintext(self):
@@ -399,7 +399,7 @@ class TestParseFormUpload:
     @pytest.mark.parametrize("content", ["", "   "], ids=["empty", "whitespace"])
     async def test_empty_content_raises(self, content):
         """Empty or whitespace-only textarea raises ValueError."""
-        with pytest.raises(PayloadEmptyError):
+        with pytest.raises(errors.PayloadEmptyError):
             await self._test_fn(content, "")
 
     async def test_file_extracts_fields(self):
@@ -416,7 +416,7 @@ class TestParseFormUpload:
 
     async def test_empty_file_raises(self):
         """Empty file raises ValueError."""
-        with pytest.raises(PayloadEmptyError):
+        with pytest.raises(errors.PayloadEmptyError):
             await self._file_fn(data=b"")
 
 

--- a/tests/web/test_errors.py
+++ b/tests/web/test_errors.py
@@ -10,6 +10,7 @@ License: Apache-2.0
 from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
+from depo.cli import defaults
 from tests.factories import HEADER_HTMX
 
 
@@ -68,9 +69,7 @@ class TestHtmxErrorPartial:
 
     def _oversize_resp(self, c: TestClient):
         """POST oversized upload with HTMX headers, return response."""
-        from depo.service.ingest import DEFAULT_MAX_SIZE_BYTES
-
-        data = {"content": "x" * (DEFAULT_MAX_SIZE_BYTES + 1), "format": ""}
+        data = {"content": "x" * (defaults.MAX_SIZE_BYTES + 1), "format": ""}
         return c.post("/upload", data=data, headers=HEADER_HTMX)
 
     def test_empty_upload_returns_partial(self, t_client: TestClient):


### PR DESCRIPTION
Fixes the non-HTMX form fallback branch in the upload dispatcher, which had
no error handling and let domain errors escape to the boundary, mislabelling
ordinary 4xx failures as 500.

Changes:
- wrap form fallback branch in try/except DepoError; render browser_error
  at the true error status
- replace three ContentFormat(fmt) call sites with format_for_extension,
  raising UnsupportedFormatError on unknown tokens
- api_upload format resolution moved inside try/except DepoError so bad
  tokens return 422 rather than escaping
- remove stale DEFAULT_MAX_SIZE_BYTES and DEFAULT_MAX_URL_LEN from
  ingest.py; source defaults from cli.defaults
- fix stale DEFAULT_MAX_SIZE_BYTES imports in test_upload.py and
  test_errors.py
- update errors.md deferred section

Out of scope: redirect-with-flash, FormatMismatchError, HTMX and API error
surfaces (already wired).