### PR TITLE
Ft: Password credentials and provisioning

### DIFF
--- a/doc/module/cli.md
+++ b/doc/module/cli.md
@@ -79,6 +79,8 @@ Click CLI entry point.
 | `depo init` | Create dirs + apply DB schema |
 | `depo serve` | Start uvicorn with app factory |
 | `depo config show` | Display resolved config fields |
+| `depo create-user` | Provision a new user with a hashed password |
+| `depo set-password` | Update an existing user's password by email or id |
 
 Config resolved at group level via `ctx.obj`.
 `serve` calls `uvicorn.run(app, host, port)`.

--- a/doc/module/cli.md
+++ b/doc/module/cli.md
@@ -19,6 +19,9 @@ class DepoConfig:
     max_size_bytes: int # default: 2**26 (64 MiB)
     max_url_len: int    # default: 2048
     log_level: Severity # default: Severity.WARNING
+    scrypt_n: int       # default: 2**16
+    scrypt_r: int       # default: 8
+    scrypt_p: int       # default: 1
 ```
 
 Frozen dataclass. Immutable after resolution.
@@ -38,6 +41,9 @@ resolution logic.
 | MAX_SIZE_BYTES | 2**26 (64 MiB) |
 | MAX_URL_LEN | 2048 |
 | LOG_LEVEL | Severity.WARNING |
+| SCRYPT_N | 2**16 |
+| SCRYPT_R | 8 |
+| SCRYPT_P | 1 |
 
 ### Functions
 

--- a/doc/module/util.md
+++ b/doc/module/util.md
@@ -37,3 +37,19 @@ Raises `PayloadTooLargeError` if size exceeds maximum.
 validate_payload(payload_bytes: bytes | None, payload_path: Path | None) -> None
 validate_size(size: int, max_size: int) -> None
 ```
+
+## password.py
+
+Password hashing and verification using stdlib scrypt.
+No external dependencies.
+
+```python
+hash_password(pw: str, *, n: int, r: int, p: int) -> str
+verify_password(pw: str, stored: str) -> bool
+```
+
+`hash_password` salts with `os.urandom`, derives via `hashlib.scrypt`,
+and returns a PHC-style string: `scrypt$n=...,r=...,p=...$salt_hex$digest_hex`.
+`verify_password` parses the stored string, recomputes the digest, and
+compares with `hmac.compare_digest`. Returns `False` on malformed input.
+Cost parameters come from config (`scrypt_n`, `scrypt_r`, `scrypt_p`).

--- a/doc/planning/handoff.md
+++ b/doc/planning/handoff.md
@@ -33,6 +33,7 @@ During the session:
 - Verify project layout with a command before specifying file edits
   or test placements. Plan from the tree, not from memory
 - Track tasks, deferrals, and doc items as they arise
+- Really consider the styling/conventions of the prompts sent and codebase
 - Commit messages in code fences, never mixed with other content
 
 Before ending a session:
@@ -125,7 +126,6 @@ note where it's documented and keep the entry here as a reminder.
 - Always discuss plan changes before executing. Debate freely but never
   silently expand scope without checking in.
 - One thing at a time. Present one question, one decision, one task.
-- Don't modify files the user is actively editing. Provide snippets instead.
 - Stubs and guidance, not implementations. Provide file stubs with signatures,
   docstrings, and test specs. Only generate full implementations when
   explicitly asked or when it's clearly busywork.
@@ -135,14 +135,6 @@ note where it's documented and keep the entry here as a reminder.
 - Hardcoded test assertions over dynamic ones to prevent false positives.
 - Test stubs must include module docstring, imports, and spec comments.
 - Don't re-ask for context already provided in conversation. Track what's been shared.
-- Pico styles `footer` element directly. Use compound selector
-  (e.g. `footer.site-footer`) to beat its specificity.
-- SVG data URI dither patterns need `background-size` scaling
-  for high-DPI. 1px bits are sub-pixel on retina screens.
-- Shadow `z-index: -1` pseudo-elements fall behind page background
-  unless an ancestor (not the parent) establishes a stacking context.
-- System mono font stacks are sufficient for retro aesthetic —
-  visual identity comes from structural choices, not typeface.
 - Replacing static asset stubs may require users to clear browser
   cache. Note in release docs.
 - Catch DepoError broadly in route handlers — covers all typed exceptions
@@ -154,7 +146,7 @@ note where it's documented and keep the entry here as a reminder.
   `get("class")` returns list or None, never crash on missing class.
 - Pico styles `article` as a card. Prefer `section` for record
   inspection views.
-- Em-dashes are forbidden in all docs and code comments.
+- Em-dashes are forbidden in all docs and code comments prefer ASCII 128bit chars.
 - Verify project layout with `cc`/bash before specifying file edits or
   test placements. Plan from the tree, not from memory.
 - `util` cannot import `model`. Util-layer enums such as error `Severity`
@@ -189,6 +181,8 @@ Commit prefixes by primary work type:
 - `Pln:` - planning decisions documented
 - `Ref:` - refactoring
 - `Fix:` - bug fixes
+- `Chr:`- Chore tasks
+- `Chk:` - Checkpoints for when work must be preserved and resumed
 
 Commits should usually stay under 300 LOC. If not, the work probably
 needs better division. Commit bodies use nested `-` lists with no line

--- a/doc/planning/mvp.md
+++ b/doc/planning/mvp.md
@@ -30,107 +30,6 @@ service, repo, and storage. Dedupe by content hash.
 
 Ordered by dependency. Each heading is roughly one PR.
 
-### Password credentials and provisioning (Branch: `ft/credentials`)
-
-*Problem: users have a `pw_hash` column but nothing produces or
-verifies a hash, and manual provisioning via raw SQL cannot compute
-one. Add a stdlib credentials module (scrypt hashing, constant-time
-verify) and a click create-user command that writes a row with a
-valid hash. Depends on `ft/users-table`. Out of scope: login route
-and sessions (`ft/login-session`); the `/upload` gate
-(`ft/upload-gate`); email-based provisioning flows (post-MVP).
-Assumes `ref/canonical-config` has landed: scalar defaults live in
-`cli/defaults.py` and `DepoConfig` sources from them.*
-
-#### Setup and gating test
-
-- [ ] Branch `ft/credentials` from `ft/users-table`.
-- [ ] Add a skipped integration test to `tests/cli/test_main.py` (new
-      `TestCreateUser` class) asserting the end state: invoking the
-      create-user command with email, name, and password writes a
-      `users` row whose stored `pw_hash` verifies against the password
-      and rejects a wrong one. `@pytest.mark.skip` until the last unit.
-  - [ ] Commit: `Tst: Add skipped gating test for user provisioning`
-
-#### TDD implementation
-
-**Hash and verify passwords with stdlib scrypt**
-(`tests/util/test_password.py`)
-
-- [ ] Red: tests asserting `hash_password(pw, *, n, r, p)` returns a
-      self-describing PHC-style string (algorithm, params, salt_hex,
-      digest_hex), `verify_password(pw, stored)` is true for the right
-      password and false for a wrong one, two hashes of the same
-      password differ (random salt), and a tampered field fails verify.
-- [ ] Add `src/depo/util/password.py`: `hash_password` using
-      `hashlib.scrypt` with an `os.urandom` salt, hex-encoded
-      (`bytes.hex`) into a PHC-style string; `verify_password` parsing
-      it (`bytes.fromhex`), recomputing, and comparing with
-      `hmac.compare_digest`. Stdlib only, no new dependency. Do not
-      reuse the Crockford codec (encode-only, built for shortcodes).
-- [ ] uv run ruff check && uv run pytest
-- [ ] Commit: `Ft: Add scrypt password hashing and verification`
-
-**Add scrypt cost parameters to config**
-(`tests/cli/test_defaults.py`, `tests/cli/test_config.py`)
-
-- [ ] Red: test asserting `DepoConfig` exposes scrypt cost fields with
-      sane defaults sourced from `cli/defaults.py`, and a resolution
-      test that an overridden value (env or TOML) coerces to int onto
-      the config, mirroring the existing override tests.
-- [ ] Add `DEFAULT_SCRYPT_N` (2**14), `DEFAULT_SCRYPT_R` (8),
-      `DEFAULT_SCRYPT_P` (1) to `cli/defaults.py`; add
-      `scrypt_n`/`scrypt_r`/`scrypt_p` fields to `DepoConfig` sourcing
-      them; add the three names to the `_coerce` `int_fields` set.
-- [ ] uv run ruff check && uv run pytest
-- [ ] Commit: `Ft: Add scrypt cost parameters to config`
-
-**Add the create-user click command**
-(`tests/cli/test_main.py`)
-
-- [ ] Red: tests asserting the command creates a user with a verifying
-      hash, errors on duplicate email or name (surfacing the repo
-      unique violation), and reads the password without echoing it.
-- [ ] Add a `create-user` command on the `cli` group in
-      `src/depo/cli/main.py` taking email and name as options and the
-      password via a hidden prompt (`click.password_option` or
-      `prompt=..., hide_input=True`); hash via `hash_password` with
-      cost params from the resolved config, write the row via
-      `insert_user`.
-- [ ] uv run ruff check && uv run pytest
-- [ ] Commit: `Ft: Add create-user admin command`
-
-**Add the set-password admin command**
-(`tests/cli/test_main.py`)
-
-- [ ] Red: tests asserting the command changes an existing user's
-      password (the new password verifies via `verify_password`, the old
-      no longer does), accepts either an email or a numeric id and
-      resolves an email through `get_user_by_email` to a uid, errors
-      cleanly if the user does not exist, and reads the new password via
-      a hidden prompt without echoing it.
-- [ ] Add a `set-password` command on the `cli` group in
-      `src/depo/cli/main.py`: resolve the target to a uid (numeric id used
-      directly; email looked up via `get_user_by_email`), hash the new
-      password via `hash_password` with cost params from the resolved
-      config, and write via `update_user_pw_hash`. Surface a clean CLI
-      error (not a traceback) when the user is not found.
-- [ ] uv run ruff check && uv run pytest
-- [ ] Commit: `Ft: Add set-password admin command`
-
-#### Integration and documentation
-
-- [ ] Unskip the `TestCreateUser` gating test; confirm it passes.
-- [ ] Update `doc/module/util.md` (password module) and
-      `doc/module/cli.md` (create-user and set-password commands); note
-      the scrypt cost params wherever config fields are documented.
-- [ ] uv run ruff check && uv run pytest
-- [ ] Commit: `Doc: ...`
-
-#### PR
-
-- [ ] gh pr create --title "Ft: Password credentials and provisioning" --body "..."
-
 ### Login and session (Branch: `ft/login-session`)
 
 *Problem: users can be created and their passwords verified, but no
@@ -456,6 +355,14 @@ Ensure all hierarchy works in pure grayscale; color remains semantic only.
   naming overlap with `SqliteRepository.insert_user`
 - Split `src/depo/repo/sqlite.py` into per-concern submodules (items,
   users, schema) once the auth sequence lands
+- Standardize scrypt cost params in password tests to minimum values
+  (n=2, r=1, p=1); some tests still use n=2**14 making the suite slow
+- Revisit scrypt N=2**16 choice against a timing benchmark on target
+  hardware; OWASP floor is 2**17, current value is a split-the-difference
+  estimate without a measured baseline
+- Replace empirical maxmem formula (256*n*r*p + 1MiB) in password.py
+  with a principled bound once OpenSSL's internal buffer requirement is
+  confirmed
 
 ### Manual Testing
 

--- a/src/depo/cli/config.py
+++ b/src/depo/cli/config.py
@@ -35,6 +35,10 @@ class DepoConfig:
     min_code_len: int = defaults.MIN_CODE_LEN
     # Logging/ErrorHandling
     log_level: Severity = defaults.LOG_LEVEL
+    # Scrypt cost parameters
+    scrypt_n: int = defaults.SCRYPT_N
+    scrypt_r: int = defaults.SCRYPT_R
+    scrypt_p: int = defaults.SCRYPT_P
 
 
 def _xdg_config_home() -> Path:
@@ -54,6 +58,7 @@ def _load_toml(path: Path) -> dict:
 def _coerce(overrides: dict) -> dict:
     """Coerce string values from env/TOML to expected types."""
     int_fields = {"port", "max_size_bytes", "max_url_len", "min_code_len"}
+    int_fields |= {"scrypt_n", "scrypt_r", "scrypt_p"}
     path_fields = {"db_path", "store_root"}
     out = {}
     for k, v in overrides.items():

--- a/src/depo/cli/defaults.py
+++ b/src/depo/cli/defaults.py
@@ -22,6 +22,12 @@ LOG_LEVEL = Severity.WARNING
 
 _XDG_DATA_HOME = "XDG_DATA_HOME"
 
+# SCRYPT crypto params
+
+SCRYPT_N = 2**14
+SCRYPT_R = 8
+SCRYPT_P = 1
+
 
 def default_store_dir() -> Path:
     """Return XDG_DATA_HOME/depo/store if set, else ./store for containerized deploys"""

--- a/src/depo/cli/defaults.py
+++ b/src/depo/cli/defaults.py
@@ -24,7 +24,7 @@ _XDG_DATA_HOME = "XDG_DATA_HOME"
 
 # SCRYPT crypto params
 
-SCRYPT_N = 2**14
+SCRYPT_N = 2**16
 SCRYPT_R = 8
 SCRYPT_P = 1
 

--- a/src/depo/cli/main.py
+++ b/src/depo/cli/main.py
@@ -4,10 +4,12 @@ CLI entry point using Click.
 
 Author: Marcus Grant
 Created: 2026-02-09
+Revised: [2026-06-17]
 License: Apache-2.0
 """
 
 import sqlite3
+import time
 from dataclasses import fields
 
 import click
@@ -15,7 +17,10 @@ from rich.console import Console
 from rich.table import Table
 
 from depo.cli.config import DepoConfig, load_config
-from depo.repo.sqlite import init_db
+from depo.model.user import User
+from depo.repo.sqlite import SqliteRepository, init_db
+from depo.util.errors import UniqueViolationError
+from depo.util.password import hash_password
 from depo.web.app import app_factory
 
 
@@ -70,3 +75,27 @@ def config_show(ctx: click.Context) -> None:
         table.add_row(f.name, str(getattr(cfg, f.name)))
     console = Console()
     console.print(table)
+
+
+@cli.command("create-user")
+@click.option("--email", required=True, prompt=True)
+@click.option("--name", required=True, prompt=True)
+@click.password_option()
+@click.pass_context
+def create_user(ctx: click.Context, email: str, name: str, password: str) -> None:
+    """Provision a new user with a hashed password."""
+    cfg: DepoConfig = ctx.obj["config"]
+    conn = sqlite3.connect(str(cfg.db_path))
+    init_db(conn)
+    repo = SqliteRepository(conn)
+    kwargs = {"n": cfg.scrypt_n, "r": cfg.scrypt_r, "p": cfg.scrypt_p}
+    pw_hash = hash_password(password, **kwargs)
+    T = int(time.time())
+    user = User(id=0, email=email, name=name, pw_hash=pw_hash, created_at=T)
+    try:
+        repo.insert_user(user)
+        conn.commit()
+    except UniqueViolationError as e:
+        raise click.ClickException(f"{e.value} is already taken") from e
+    finally:
+        conn.close()

--- a/src/depo/cli/main.py
+++ b/src/depo/cli/main.py
@@ -99,3 +99,33 @@ def create_user(ctx: click.Context, email: str, name: str, password: str) -> Non
         raise click.ClickException(f"{e.value} is already taken") from e
     finally:
         conn.close()
+
+
+@cli.command("set-password")
+@click.option("--target", required=True, prompt=True, help="Email or numeric user id.")
+@click.password_option()
+@click.pass_context
+def set_password(ctx: click.Context, target: str, password: str) -> None:
+    """Update an existing user's password."""
+    cfg: DepoConfig = ctx.obj["config"]
+    conn = sqlite3.connect(str(cfg.db_path))
+    init_db(conn)
+    repo = SqliteRepository(conn)
+    try:
+        if target.isdigit():
+            uid = int(target)
+        else:
+            user = repo.get_user_by_email(target)
+            if user is None:
+                raise click.ClickException(f"No user found for {target}")
+            uid = user.id
+        kwargs = {"n": cfg.scrypt_n, "r": cfg.scrypt_r, "p": cfg.scrypt_p}
+        pw_hash = hash_password(password, **kwargs)
+        repo.update_user_pw_hash(uid, pw_hash)
+        conn.commit()
+    except click.ClickException:
+        raise
+    except Exception as e:
+        raise click.ClickException(str(e)) from e
+    finally:
+        conn.close()

--- a/src/depo/util/password.py
+++ b/src/depo/util/password.py
@@ -14,7 +14,8 @@ import os
 def hash_password(pw: str, *, n: int, r: int, p: int) -> str:
     """Hash a password using scrypt, returning a PHC-style string."""
     salt = os.urandom(16)
-    dk = hashlib.scrypt(pw.encode(), salt=salt, n=n, r=r, p=p)
+    maxmem = 256 * n * r * p + 1024 * 1024
+    dk = hashlib.scrypt(pw.encode(), salt=salt, n=n, r=r, p=p, maxmem=maxmem)
     return f"scrypt$n={n},r={r},p={p}${salt.hex()}${dk.hex()}"
 
 
@@ -35,5 +36,6 @@ def verify_password(pw: str, stored: str) -> bool:
         expected = bytes.fromhex(digest_hex)
     except (KeyError, ValueError):
         return False
-    dk = hashlib.scrypt(pw.encode(), salt=salt, n=n, r=r, p=p)
+    maxmem = 256 * n * r * p + 1024 * 1024
+    dk = hashlib.scrypt(pw.encode(), salt=salt, n=n, r=r, p=p, maxmem=maxmem)
     return hmac.compare_digest(dk, expected)

--- a/src/depo/util/password.py
+++ b/src/depo/util/password.py
@@ -1,0 +1,39 @@
+# src/depo/util/password.py
+"""
+Password hashing and verification using stdlib scrypt.
+Author: Marcus Grant
+Created: 2026-06-17
+License: Apache-2.0
+"""
+
+import hashlib
+import hmac
+import os
+
+
+def hash_password(pw: str, *, n: int, r: int, p: int) -> str:
+    """Hash a password using scrypt, returning a PHC-style string."""
+    salt = os.urandom(16)
+    dk = hashlib.scrypt(pw.encode(), salt=salt, n=n, r=r, p=p)
+    return f"scrypt$n={n},r={r},p={p}${salt.hex()}${dk.hex()}"
+
+
+def verify_password(pw: str, stored: str) -> bool:
+    """Verify a password against a stored PHC-style scrypt hash."""
+    try:
+        algo, params, salt_hex, digest_hex = stored.split("$")
+    except ValueError:
+        return False
+    if algo != "scrypt":
+        return False
+    try:
+        param_dict = dict(kv.split("=") for kv in params.split(","))
+        n = int(param_dict["n"])
+        r = int(param_dict["r"])
+        p = int(param_dict["p"])
+        salt = bytes.fromhex(salt_hex)
+        expected = bytes.fromhex(digest_hex)
+    except (KeyError, ValueError):
+        return False
+    dk = hashlib.scrypt(pw.encode(), salt=salt, n=n, r=r, p=p)
+    return hmac.compare_digest(dk, expected)

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -70,6 +70,9 @@ class TestDepoConfig:
             ("max_url_len", int, False, defaults.MAX_URL_LEN),
             ("min_code_len", int, False, defaults.MIN_CODE_LEN),
             ("log_level", Severity, False, Severity.WARNING),
+            ("scrypt_n", int, False, defaults.SCRYPT_N),
+            ("scrypt_r", int, False, defaults.SCRYPT_R),
+            ("scrypt_p", int, False, defaults.SCRYPT_P),
         ],
     )
     def test_simple_fields(self, name, typ, required, default):
@@ -215,6 +218,19 @@ class TestLoadConfigEnv:
         monkeypatch.setenv("DEPO_LOG_LEVEL", "BANANA")
         with pytest.raises(ConfigError):
             load_config()
+
+    def test_env_scrypt_int_coercion(self, monkeypatch, tmp_path):
+        """DEPO_SCRYPT_N/R/P env vars coerce to int on DepoConfig."""
+        self._clear_depo_env(monkeypatch)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DEPO_SCRYPT_N", "4096")
+        monkeypatch.setenv("DEPO_SCRYPT_R", "4")
+        monkeypatch.setenv("DEPO_SCRYPT_P", "2")
+        cfg = load_config()
+        assert cfg.scrypt_n == 4096
+        assert cfg.scrypt_r == 4
+        assert cfg.scrypt_p == 2
 
 
 class TestLoadConfigFlag:

--- a/tests/cli/test_defaults.py
+++ b/tests/cli/test_defaults.py
@@ -40,6 +40,6 @@ class TestScryptDefaults:
 
     def test_scrypt_constants(self):
         """SCRYPT_N, SCRYPT_R, SCRYPT_P have correct default values."""
-        assert defaults.SCRYPT_N == 2**14
+        assert defaults.SCRYPT_N == 2**16
         assert defaults.SCRYPT_R == 8
         assert defaults.SCRYPT_P == 1

--- a/tests/cli/test_defaults.py
+++ b/tests/cli/test_defaults.py
@@ -8,7 +8,7 @@ License: Apache-2.0
 
 from pathlib import Path
 
-from depo.cli.defaults import _XDG_DATA_HOME, default_db_path, default_store_dir
+from depo.cli import defaults
 
 
 class TestDefaultPaths:
@@ -16,20 +16,30 @@ class TestDefaultPaths:
 
     def test_store_dir_xdg(self, monkeypatch, tmp_path):
         """XDG_DATA_HOME set yields its depo/store subdir."""
-        monkeypatch.setenv(_XDG_DATA_HOME, str(tmp_path))
-        assert default_store_dir() == tmp_path / "depo" / "store"
+        monkeypatch.setenv(defaults._XDG_DATA_HOME, str(tmp_path))
+        assert defaults.default_store_dir() == tmp_path / "depo" / "store"
 
     def test_store_dir_fallback(self, monkeypatch):
         """No XDG_DATA_HOME falls back to ./store."""
-        monkeypatch.delenv(_XDG_DATA_HOME, raising=False)
-        assert default_store_dir() == Path.cwd() / "store"
+        monkeypatch.delenv(defaults._XDG_DATA_HOME, raising=False)
+        assert defaults.default_store_dir() == Path.cwd() / "store"
 
     def test_db_path_xdg(self, monkeypatch, tmp_path):
         """XDG_DATA_HOME set yields its depo/depo.db path."""
-        monkeypatch.setenv(_XDG_DATA_HOME, str(tmp_path))
-        assert default_db_path() == tmp_path / "depo" / "depo.db"
+        monkeypatch.setenv(defaults._XDG_DATA_HOME, str(tmp_path))
+        assert defaults.default_db_path() == tmp_path / "depo" / "depo.db"
 
     def test_db_path_fallback(self, monkeypatch):
         """No XDG_DATA_HOME falls back to ./depo.db."""
-        monkeypatch.delenv(_XDG_DATA_HOME, raising=False)
-        assert default_db_path() == Path.cwd() / "depo.db"
+        monkeypatch.delenv(defaults._XDG_DATA_HOME, raising=False)
+        assert defaults.default_db_path() == Path.cwd() / "depo.db"
+
+
+class TestScryptDefaults:
+    """Tests for scrypt cost constants in defaults."""
+
+    def test_scrypt_constants(self):
+        """SCRYPT_N, SCRYPT_R, SCRYPT_P have correct default values."""
+        assert defaults.SCRYPT_N == 2**14
+        assert defaults.SCRYPT_R == 8
+        assert defaults.SCRYPT_P == 1

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -8,6 +8,7 @@ Revised [2026-06-17]
 License: Apache-2.0
 """
 
+import sqlite3
 from dataclasses import fields
 from pathlib import Path
 from unittest.mock import patch
@@ -18,12 +19,36 @@ from tests.factories import make_config
 
 from depo.cli.config import DepoConfig
 from depo.cli.main import cli
+from depo.repo.sqlite import SqliteRepository, init_db
+from depo.util.password import verify_password
 
 
 def _invoke(*args, tmp_path: Path | None = None):
     cfg = make_config(tmp_path) if tmp_path else DepoConfig()
     runner = CliRunner()
     return runner.invoke(cli, list(args), obj={"config": cfg}, env={"COLUMNS": "300"})  # type: ignore
+
+
+def _invoke_create_user(tmppath: Path, email: str, name: str, password: str):
+    runner = CliRunner()
+    return runner.invoke(
+        cli,
+        ["create-user", "--email", email, "--name", name],
+        obj={"config": make_config(tmppath)},
+        input=f"{password}\n{password}\n",
+        env={"COLUMNS": "300"},
+    )
+
+
+def _invoke_set_password(tmp_path, target: str, password: str):
+    runner = CliRunner()
+    return runner.invoke(
+        cli,
+        ["set-password", "--target", target],
+        obj={"config": make_config(tmp_path)},
+        input=f"{password}\n{password}\n",
+        env={"COLUMNS": "300"},
+    )
 
 
 class TestInit:
@@ -89,16 +114,6 @@ class TestServe:
 class TestCreateUser:
     """Gating e2e: create-user provisions a verifiable password hash."""
 
-    def _invoke_create_user(self, tmppath: Path, email: str, name: str, password: str):
-        runner = CliRunner()
-        return runner.invoke(
-            cli,
-            ["create-user", "--email", email, "--name", name],
-            obj={"config": make_config(tmppath)},
-            input=f"{password}\n{password}\n",
-            env={"COLUMNS": "300"},
-        )
-
     @pytest.mark.skip(
         reason="create-user not implemented until final ft/credentials unit"
     )
@@ -109,9 +124,9 @@ class TestCreateUser:
     def test_duplicate_email_errors(self, tmp_path):
         """Errors cleanly when a user with the same email already exists."""
         _invoke("init", tmp_path=tmp_path)
-        self._invoke_create_user(tmp_path, "dupe@example.com", "UserOne", "password")
+        _invoke_create_user(tmp_path, "dupe@example.com", "UserOne", "password")
         args = tmp_path, "dupe@example.com", "UserTwo", "password"
-        result = self._invoke_create_user(*args)
+        result = _invoke_create_user(*args)
         assert result.exit_code != 0
         assert "dupe@example.com" in result.output
 
@@ -119,9 +134,9 @@ class TestCreateUser:
         """Errors cleanly when a user with the same name already exists."""
         _invoke("init", tmp_path=tmp_path)
         args = (tmp_path, "user1@example.com", "SharedName", "password")
-        self._invoke_create_user(*args)
+        _invoke_create_user(*args)
         args = tmp_path, "user2@example.com", "SharedName", "password"
-        result = self._invoke_create_user(*args)
+        result = _invoke_create_user(*args)
         assert result.exit_code != 0
         assert "SharedName" in result.output
 
@@ -129,5 +144,51 @@ class TestCreateUser:
         """Password input is not echoed to output."""
         _invoke("init", tmp_path=tmp_path)
         args = tmp_path, "user@example.com", "User", "s3cr3tpassword"
-        result = self._invoke_create_user(*args)
+        result = _invoke_create_user(*args)
         assert "s3cr3tpassword" not in result.output
+
+
+class TestSetPassword:
+    """Tests for the set-password admin command."""
+
+    def test_changes_password_by_email(self, tmp_path):
+        """New password verifies; old password no longer does."""
+        _invoke("init", tmp_path=tmp_path)
+        args = (tmp_path, "user@example.com", "User", "oldpassword")
+        _invoke_create_user(*args)
+        _invoke_set_password(tmp_path, "user@example.com", "newpassword")
+        conn = sqlite3.connect(str(make_config(tmp_path).db_path))
+        init_db(conn)
+        user = SqliteRepository(conn).get_user_by_email("user@example.com")
+        assert user is not None
+        assert verify_password("newpassword", user.pw_hash)
+        assert not verify_password("oldpassword", user.pw_hash)
+
+    def test_changes_password_by_id(self, tmp_path):
+        """Accepts a numeric user id in place of email."""
+        _invoke("init", tmp_path=tmp_path)
+        _invoke_create_user(tmp_path, "user@example.com", "User", "oldpassword")
+        conn = sqlite3.connect(str(make_config(tmp_path).db_path))
+        init_db(conn)
+        user = SqliteRepository(conn).get_user_by_email("user@example.com")
+        assert user is not None
+        conn.close()
+        _invoke_set_password(tmp_path, str(user.id), "newpassword")
+        conn = sqlite3.connect(str(make_config(tmp_path).db_path))
+        init_db(conn)
+        user = SqliteRepository(conn).get_user_by_email("user@example.com")
+        assert user is not None
+        assert verify_password("newpassword", user.pw_hash)
+
+    def test_errors_on_unknown_user(self, tmp_path):
+        """Errors cleanly when the target user does not exist."""
+        _invoke("init", tmp_path=tmp_path)
+        result = _invoke_set_password(tmp_path, "ghost@example.com", "password")
+        assert result.exit_code != 0
+
+    def test_password_not_echoed(self, tmp_path):
+        """New password input is not echoed to output."""
+        _invoke("init", tmp_path=tmp_path)
+        _invoke_create_user(tmp_path, "user@example.com", "User", "oldpassword")
+        result = _invoke_set_password(tmp_path, "user@example.com", "s3cr3tnew")
+        assert "s3cr3tnew" not in result.output

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -90,29 +90,4 @@ class TestServe:
 class TestCreateUser:
     """Gating e2e: create-user provisions a verifiable password hash."""
 
-    def test_creates_user_with_verifying_hash(self, tmp_path):
-        import sqlite3
-
-        from depo.util.password import verify_password  # type: ignore[import]
-
-        from depo.repo.sqlite import SqliteRepository, init_db
-
-        pw = "s3cr3tpassword"
-        cfg = make_config(tmp_path)
-        runner = CliRunner()
-        _invoke("init", tmp_path=tmp_path)
-        result = runner.invoke(
-            cli,
-            ["create-user", "--email", "newuser@example.com", "--name", "NewUser"],
-            obj={"config": cfg},
-            input=f"{pw}\n{pw}\n",
-            env={"COLUMNS": "300"},
-        )
-        assert result.exit_code == 0
-        conn = sqlite3.connect(str(cfg.db_path))
-        init_db(conn)
-        repo = SqliteRepository(conn)
-        user = repo.get_user_by_email("newuser@example.com")
-        assert user is not None
-        assert verify_password(pw, user.pw_hash)
-        assert not verify_password("wrongpassword", user.pw_hash)
+    # def test_creates_user_with_verifying_hash(self, tmp_path): ...

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -13,7 +13,6 @@ from dataclasses import fields
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
 from click.testing import CliRunner
 from tests.factories import make_config
 
@@ -114,12 +113,27 @@ class TestServe:
 class TestCreateUser:
     """Gating e2e: create-user provisions a verifiable password hash."""
 
-    @pytest.mark.skip(
-        reason="create-user not implemented until final ft/credentials unit"
-    )
     def test_creates_user_with_verifying_hash(self, tmp_path):
-        _ = tmp_path
-        pass
+        pw = "s3cr3tpassword"
+        cfg = make_config(tmp_path)
+        runner = CliRunner()
+        _invoke("init", tmp_path=tmp_path)
+        args = ["create-user", "--email", "newuser@example.com", "--name", "NewUser"]
+        result = runner.invoke(
+            cli,
+            args,
+            obj={"config": cfg},
+            input=f"{pw}\n{pw}\n",
+            env={"COLUMNS": "300"},
+        )
+        assert result.exit_code == 0
+        conn = sqlite3.connect(str(cfg.db_path))
+        init_db(conn)
+        repo = SqliteRepository(conn)
+        user = repo.get_user_by_email("newuser@example.com")
+        assert user is not None
+        assert verify_password(pw, user.pw_hash)
+        assert not verify_password("wrongpassword", user.pw_hash)
 
     def test_duplicate_email_errors(self, tmp_path):
         """Errors cleanly when a user with the same email already exists."""

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -4,6 +4,7 @@ Tests for CLI commands.
 
 Author: Marcus Grant
 Created: 2026-02-09
+Revised [2026-06-17]
 License: Apache-2.0
 """
 
@@ -11,6 +12,7 @@ from dataclasses import fields
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
 from click.testing import CliRunner
 from tests.factories import make_config
 
@@ -82,3 +84,35 @@ class TestServe:
             result = _invoke("serve", tmp_path=tmp_path)
         assert result.exit_code == 0
         mock_run.assert_called_once()
+
+
+@pytest.mark.skip(reason="create-user not implemented until final ft/credentials unit")
+class TestCreateUser:
+    """Gating e2e: create-user provisions a verifiable password hash."""
+
+    def test_creates_user_with_verifying_hash(self, tmp_path):
+        import sqlite3
+
+        from depo.util.password import verify_password  # type: ignore[import]
+
+        from depo.repo.sqlite import SqliteRepository, init_db
+
+        pw = "s3cr3tpassword"
+        cfg = make_config(tmp_path)
+        runner = CliRunner()
+        _invoke("init", tmp_path=tmp_path)
+        result = runner.invoke(
+            cli,
+            ["create-user", "--email", "newuser@example.com", "--name", "NewUser"],
+            obj={"config": cfg},
+            input=f"{pw}\n{pw}\n",
+            env={"COLUMNS": "300"},
+        )
+        assert result.exit_code == 0
+        conn = sqlite3.connect(str(cfg.db_path))
+        init_db(conn)
+        repo = SqliteRepository(conn)
+        user = repo.get_user_by_email("newuser@example.com")
+        assert user is not None
+        assert verify_password(pw, user.pw_hash)
+        assert not verify_password("wrongpassword", user.pw_hash)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -86,8 +86,48 @@ class TestServe:
         mock_run.assert_called_once()
 
 
-@pytest.mark.skip(reason="create-user not implemented until final ft/credentials unit")
 class TestCreateUser:
     """Gating e2e: create-user provisions a verifiable password hash."""
 
-    # def test_creates_user_with_verifying_hash(self, tmp_path): ...
+    def _invoke_create_user(self, tmppath: Path, email: str, name: str, password: str):
+        runner = CliRunner()
+        return runner.invoke(
+            cli,
+            ["create-user", "--email", email, "--name", name],
+            obj={"config": make_config(tmppath)},
+            input=f"{password}\n{password}\n",
+            env={"COLUMNS": "300"},
+        )
+
+    @pytest.mark.skip(
+        reason="create-user not implemented until final ft/credentials unit"
+    )
+    def test_creates_user_with_verifying_hash(self, tmp_path):
+        _ = tmp_path
+        pass
+
+    def test_duplicate_email_errors(self, tmp_path):
+        """Errors cleanly when a user with the same email already exists."""
+        _invoke("init", tmp_path=tmp_path)
+        self._invoke_create_user(tmp_path, "dupe@example.com", "UserOne", "password")
+        args = tmp_path, "dupe@example.com", "UserTwo", "password"
+        result = self._invoke_create_user(*args)
+        assert result.exit_code != 0
+        assert "dupe@example.com" in result.output
+
+    def test_duplicate_name_errors(self, tmp_path):
+        """Errors cleanly when a user with the same name already exists."""
+        _invoke("init", tmp_path=tmp_path)
+        args = (tmp_path, "user1@example.com", "SharedName", "password")
+        self._invoke_create_user(*args)
+        args = tmp_path, "user2@example.com", "SharedName", "password"
+        result = self._invoke_create_user(*args)
+        assert result.exit_code != 0
+        assert "SharedName" in result.output
+
+    def test_password_not_echoed(self, tmp_path):
+        """Password input is not echoed to output."""
+        _invoke("init", tmp_path=tmp_path)
+        args = tmp_path, "user@example.com", "User", "s3cr3tpassword"
+        result = self._invoke_create_user(*args)
+        assert "s3cr3tpassword" not in result.output

--- a/tests/repo/test_sqlite.py
+++ b/tests/repo/test_sqlite.py
@@ -458,10 +458,6 @@ class TestUserCrud:
 class TestUserPersistence:
     """End-to-end gating test for user persistence round-trip."""
 
-    # should round-trip an inserted User by id and by email,
-    # asserting both fetches return a User equal to the inserted one.
-    # Skipped until the user repo CRUD unit lands.
-
     def test_user_round_trips_by_id_and_email(self, t_repo):
         """Insert a User and fetch it by both id and email."""
         user = make_user(id=1, email="marcus@test.se")

--- a/tests/util/test_password.py
+++ b/tests/util/test_password.py
@@ -1,0 +1,52 @@
+# tests/util/test_password.py
+"""
+Tests for depo.util.password.
+Author: Marcus Grant
+Created: 2026-06-17
+License: Apache-2.0
+"""
+
+from depo.util.password import hash_password, verify_password
+
+
+class TestHashPassword:
+    """Tests for hash_password."""
+
+    def test_returns_phc_style_string(self):
+        """Returns a PHC-style string with algorithm, params, salt_hex, digest_hex."""
+        result = hash_password("hunter2", n=2, r=8, p=1)
+        parts = result.split("$")
+        assert parts[0] == "scrypt"
+        assert "n=" in parts[1]
+        assert "r=" in parts[1]
+        assert "p=" in parts[1]
+        assert len(parts[2]) > 0
+        assert len(parts[3]) > 0
+
+    def test_random_salt_produces_unique_hashes(self):
+        """Produces unique hashes for the same password due to random salt."""
+        # should return different strings on two calls with identical inputs
+        pword, kw = "fO0B@r", {"n": 2**14, "r": 8, "p": 1}
+        a, b = hash_password(pword, **kw), hash_password(pword, **kw)
+        assert a != b
+
+
+class TestVerifyPassword:
+    """Tests for verify_password."""
+
+    def test_correct_password_verifies(self):
+        """Returns True when the password matches the stored hash."""
+        stored = hash_password("hunter2", n=2, r=8, p=1)
+        assert verify_password("hunter2", stored) is True
+
+    def test_wrong_password_fails(self):
+        """Returns False when the password does not match the stored hash."""
+        stored = hash_password("hunter2", n=2, r=8, p=1)
+        assert verify_password("wrong", stored) is False
+
+    def test_tampered_digest_fails(self):
+        """Returns False when the digest field of the stored hash is tampered."""
+        stored = hash_password("hunter2", n=2, r=8, p=1)
+        parts = stored.split("$")
+        parts[3] = "00" * 32
+        assert verify_password("hunter2", "$".join(parts)) is False


### PR DESCRIPTION
Adds stdlib scrypt password hashing and verification, wires cost
parameters into DepoConfig, and provides create-user and set-password
admin CLI commands for user provisioning.

- password.py: hash_password (PHC-style scrypt string) and
  verify_password (hmac.compare_digest) in depo.util, stdlib only
- scrypt cost params (SCRYPT_N=2**16, SCRYPT_R=8, SCRYPT_P=1) added
  to cli/defaults.py and DepoConfig, coerced via _coerce int_fields
- create-user command: --email, --name, hidden double-prompt password,
  surfaces UniqueViolationError as ClickException
- set-password command: --target accepts email or numeric id, hidden
  double-prompt, errors cleanly on unknown user
- N=2**16 chosen over OWASP floor (2**17) for latency/security
  tradeoff; explicit maxmem passed to hashlib.scrypt to clear
  OpenSSL's 32MiB default cap
