### PR TITLE
Ft: Login session config infra

### DIFF
--- a/doc/module/cli.md
+++ b/doc/module/cli.md
@@ -22,6 +22,8 @@ class DepoConfig:
     scrypt_n: int       # default: 2**16
     scrypt_r: int       # default: 8
     scrypt_p: int       # default: 1
+    session_secret: str # default: "" (force-fail sentinel; must be set)
+    session_https_only: bool # default: False (plain-HTTP LAN deploy)
 ```
 
 Frozen dataclass. Immutable after resolution.
@@ -44,6 +46,8 @@ resolution logic.
 | SCRYPT_N | 2**16 |
 | SCRYPT_R | 8 |
 | SCRYPT_P | 1 |
+| SESSION_SECRET | "" (force-fail sentinel) |
+| SESSION_HTTPS_ONLY | False |
 
 ### Functions
 
@@ -64,8 +68,13 @@ load_config(*, config_path: Path | None = None) -> DepoConfig
 **Resolution order:**
 defaults → XDG config.toml → ./depo.toml → DEPO_* env → --config flag.
 
-Each layer overrides the previous.
-`_coerce()` handles int fields and `expanduser` from env/TOML strings.
+`_coerce()` handles int and bool fields and `expanduser` from env/TOML
+strings. Bool fields use `_coerce_bool`, which accepts truthy tokens
+(`true`, `yes`, `on`, `1`) and falsy tokens (`false`, `no`, `off`, `0`)
+case-insensitively, and raises `ConfigError` on unrecognized input.
+`session_secret` must be non-empty after resolution or `load_config`
+raises `ConfigError`; the `""` default is a deliberate sentinel that
+prevents the app booting without an operator-supplied secret.
 DB and store paths resolve independently.
 
 ## main.py

--- a/doc/planning/handoff.md
+++ b/doc/planning/handoff.md
@@ -1,177 +1,118 @@
 # Handoff
 
 This document is both a template and a living handoff. Sections marked
-**[static]** stay across all handoffs. Sections marked **[per-session]**
+[static] stay across all handoffs. Sections marked [per-session]
 get replaced each time.
 
-## How to use this document **[static]**
+## How to use this document [static]
 
-This handoff is read by a collaborator at the start of a session.
-The collaborator does not have direct access to the project filesystem.
-The user shares file contents by running shell commands and piping
-output to clipboard with their `cc` command.
-The collaborator's role is to suggest commands for the user to run,
-then work with whatever they paste back.
+This handoff is read by a collaborator at the start of each session. The
+collaborator has no direct filesystem access. The user shares file
+contents by piping shell command output to clipboard with their `cc`
+command. The collaborator suggests commands for the user to run, then
+works with whatever comes back.
 
-Sections marked **[static]** persist across all handoffs. Sections marked
-**[per-session]** get replaced each time.
+Sections marked [static] persist across all handoffs. Sections marked
+[per-session] are rewritten fresh each session.
 
 At session start:
 
 - Read this document in full
-- Follow links to planning and reference docs only as needed
-  for the current work
-
-During the session:
-
-- Stubs, snippets, and instructions over full implementations
-- One task at a time, one question at a time
-- Provide `cc`-piped commands to gather context, don't ask
-  the user to paste. Combine into single commands where possible.
-  grep/sed over cat — never cat whole files unless small and
-  fully needed
-- Verify project layout with a command before specifying file edits
-  or test placements. Plan from the tree, not from memory
-- Track tasks, deferrals, and doc items as they arise
-- Really consider the styling/conventions of the prompts sent and codebase
-- Commit messages in code fences, never mixed with other content
+- Follow links to planning and reference docs only as needed for the
+  current work
 
 Before ending a session:
 
-- Write per-session sections fresh from current session context.
-  Don't carry forward stale content from previous handoffs
-- Copy static sections verbatim, with any updates made during
-  the session
-- Trim completed items from planning docs, move to reference docs
-- Document deferrals in the appropriate planning doc with
-  cross-references
-- Add new session learnings
-- Present the completed handoff for the user to copy and persist
+- Rewrite the per-session sections fresh from current context; do not
+  carry forward stale content from a previous handoff
+- Carry static sections forward, with any updates made during the session
+- Trim completed items from planning docs
+- Record deferrals in the appropriate planning doc, not just here
+- Present the finished handoff for the user to persist
 
-## Orientation **[per-session]**
+## Test fixtures and factories [static]
 
-Date: 2026-05-29
+Shared test scaffolding lives in two places. Examine the existing ones
+before writing a new test module or fixture; the suite leans on them
+heavily and a new test that rolls its own setup instead of reusing them
+is almost always wrong.
 
-What just finished:
+- Factories in `tests/factories/` build domain objects and wired test
+  apps. `make_config` builds a `DepoConfig` under a tmp path;
+  `make_client` builds a wired `TestClient`; `make_user` and friends
+  build model instances. Keyword overrides replace defaults.
+- Fixtures in `tests/fixtures/` provide ready-to-use test dependencies.
+  The `t_*` naming marks them: `t_client`, `t_browser`, `t_htmx` for
+  the three client flavors, `t_conn`/`t_db`/`t_repo`/`t_store` for the
+  storage layers, `t_seeded` for an app pre-loaded with sample items.
+- Isolation helpers compose setup: e.g. `_isolate_config_env` clears
+  `DEPO_*`, sets a valid session secret, points XDG at tmp, and chdirs.
+  Prefer an autouse fixture calling a module-level helper over repeating
+  setup per method.
 
-- Planned the error-logging work end to end. Errors carry a self-describing
-  `severity` (new `Severity` IntEnum, set per domain base with leaf
-  overrides). The three builders in `web/error.py` are the single logging
-  seam through a `_log` helper. An app-level exception handler backstops
-  unexpected non-DepoError exceptions.
-- Split it into two PRs, both written as task blocks in mvp.md: Error
-  logging foundation (`ft/error-logging`, additive expected-error logging)
-  and Unexpected-error boundary (`ref/error-boundary`, the handler plus
-  `htmx_error` normalization and `hx_upload` thinning).
-- Added the Task Planning guide (`doc/planning/tasks.md`), linked from the
-  planning README and referenced in this handoff.
+When the shared scaffolding changes, note it in the per-session Layer
+status so the next reader knows.
 
-What's in progress:
+## Conventions [static]
 
-- Nothing. Planning only, no source changed.
+### Working rhythm
 
-What's next:
+- One thing at a time. One question, one decision, one task per exchange.
+- Pre-change, await, post-change. The user pastes the current state of
+  the code, the collaborator gives edit guidance, the user applies it and
+  pastes the result. This rhythm is what keeps the collaborator from
+  pre-filling work that is the user's to write.
+- Discuss plan changes before executing. Debate freely, but never
+  silently expand scope or nest unplanned work without checking in. A
+  better path to higher-quality code is welcome; springing it is not.
+- Provide a commit message before moving to the next task.
+- Don't re-ask for context already provided. Track what's been shared.
 
-- Execute Error logging foundation (`ft/error-logging`) in [mvp.md](./mvp.md),
-  then Unexpected-error boundary (`ref/error-boundary`).
-- Loose end: the non-logging items that left the old "Error handling
-  (deferred)" section need a home. `StorageError` and `FormatMismatchError`
-  fit existing unplanned.md sections; the logging observability follow-up
-  (request IDs, middleware, JSON formatting), validation extraction, the
-  LinkItem format gap, MIME review, and bug-report UX read as v0.2. Place
-  against v0.2.md next session.
+### Context economy
 
-## Layer status **[per-session]**
+- Prefer surgical retrieval over reading whole files. grep for headers or
+  symbols, sed the specific range, `git diff` to review changes. Reach for
+  cat when the whole file is genuinely needed or it is small enough not to
+  matter.
+- Verify project layout before specifying file edits or test placements.
+  Plan from the tree, not from memory; planning docs can be wrong about
+  exact names and paths.
 
-| Layer | Status | Notes |
-|-------|--------|-------|
-| doc/planning | changed | mvp.md PR 1/PR 2 blocks replace the old deferred checklist; new tasks.md; README and handoff link tasks.md |
-| source | unchanged | planning only, no code written this session |
+### Architecture
 
-## Known issues **[per-session]**
+- Dependencies flow inward: web, service, repo, storage, model, util.
+  Never outward. `util` importing `model` is the canonical violation;
+  util-layer enums live in `util`.
+- Route ordering matters in Starlette. Specific routes register first,
+  wildcards (`/{code}`) last.
 
-- None open. The previous `hx_upload` silent-swallow is now tracked as
-  planned work: PR 1's builder logging closes the swallow, PR 2 removes the
-  bare except.
+### Style
 
-## Test fixtures **[per-session]**
+- ASCII-128 only in all docs and code. No em-dashes, no arrows, no
+  emoji, no section symbols.
+- Header levels, not bold markers, for structure in docs.
 
-Verified against the tree this session.
+### Testing
 
-Factories (`tests/factories/`): `__init__.py`, `db.py`, `models.py`,
-`payloads.py`. `make_client` builds the wired TestClient.
+- Hardcoded test assertions over dynamic ones, to prevent false positives.
+- Examine existing fixtures and factories before writing a new test
+  module. See the Test fixtures and factories section.
 
-Fixtures (`tests/fixtures/__init__.py`):
+### Documentation and planning
 
-- `t_conn`, `t_db`, `t_repo`, `t_store`, `t_orch_env`
-- `t_client` bare TestClient, empty db and store
-- `t_browser` same with `Accept: text/html`
-- `t_htmx` same with `HX-Request: true`
-- `t_seeded` `SeededApp` bundling `.client`/`.browser`/`.htmx` and one
-  `.txt`/`.pic`/`.link` item each
+- Read planning docs as needed for current work, not in full every
+  session.
+- Deferrals go in the appropriate planning doc, cross-referenced, not
+  just in the handoff.
+- Completed planning items get trimmed; reference material moves to
+  `doc/design/` and `doc/module/`. Planning docs live in `doc/planning/`.
+- See [planning README](./README.md) for current priorities.
+- New tasks and PRs follow the [Task Planning](./tasks.md) guide: one PR
+  per task, four phases (setup and gating test, TDD implementation,
+  integration and documentation, PR), descriptively named units, commits
+  under 300 lines.
 
-No fixture changes this session. PR 2 will add a
-`raise_server_exceptions=False` client fixture to observe the boundary
-handler's response.
-
-## Session learnings **[static, cumulative]**
-
-Add new learnings as they come up during a session.
-Do not remove old ones.
-If a learning becomes a formal convention,
-note where it's documented and keep the entry here as a reminder.
-
-- Always run `uv run ruff check` before pytest. Use `uv run` for all
-  project python commands.
-- Always discuss plan changes before executing. Debate freely but never
-  silently expand scope without checking in.
-- One thing at a time. Present one question, one decision, one task.
-- Stubs and guidance, not implementations. Provide file stubs with signatures,
-  docstrings, and test specs. Only generate full implementations when
-  explicitly asked or when it's clearly busywork.
-- Always provide a commit message before moving on to the next task.
-- Route ordering matters in FastAPI. Specific routes register first,
-  wildcards last.
-- Hardcoded test assertions over dynamic ones to prevent false positives.
-- Test stubs must include module docstring, imports, and spec comments.
-- Don't re-ask for context already provided in conversation. Track what's been shared.
-- Replacing static asset stubs may require users to clear browser
-  cache. Note in release docs.
-- Catch DepoError broadly in route handlers — covers all typed exceptions
-  via inheritance. Domain base classes need passthrough constructors or
-  subclasses must call DepoError.**init** directly.
-- `DepoError.message` is a class attribute default; set `self.message`
-  in `__init__` for instance messages to work correctly.
-- BS4 class checks use `find("tag", class_="name")` pattern;
-  `get("class")` returns list or None, never crash on missing class.
-- Pico styles `article` as a card. Prefer `section` for record
-  inspection views.
-- Em-dashes are forbidden in all docs and code comments prefer ASCII 128bit chars.
-- Verify project layout with `cc`/bash before specifying file edits or
-  test placements. Plan from the tree, not from memory.
-- `util` cannot import `model`. Util-layer enums such as error `Severity`
-  live in `util`, not `model/enums.py`.
-- `caplog` is not yet used in the suite. Log-capture tests need
-  `caplog.set_level(...)` and the `depo` logger to propagate.
-- Testing an app-level exception handler needs
-  `TestClient(raise_server_exceptions=False)`. The default re-raises.
-- Errors self-describe with a `severity` member, the builders are the single
-  logging seam, and an app-level handler backstops non-DepoError exceptions.
-
-## Conventions **[static]**
-
-- Read planning docs as needed for current work, not in full every session
-- Update session learnings during the session, not just at the end
-- Deferrals go in planning docs, not just the handoff
-- Completed planning items get trimmed and moved to reference docs
-- Reference docs live in `doc/design/` and `doc/module/`
-- Planning docs live in `doc/planning/`
-- See [planning README](./README.md) for current priorities
-- New tasks and PRs follow the [Task Planning](./tasks.md) guide: one PR per
-  task, four phases (setup and gating test, TDD implementation, integration
-  and documentation, PR), descriptively named units, commits under 300 lines
-
-### Commit and PR rules
+## Commit and PR rules [static]
 
 Commit prefixes by primary work type:
 
@@ -192,12 +133,54 @@ PRs get a title reflecting the branch name. Branches follow the same
 prefix pattern: `ft/core-api-layer`, `tst/client-fixture`,
 `doc/design-refs`, etc.
 
-### Stub workflow
+## Stub workflow [static]
 
-We work by providing stubs, not full implementations.
-TDD by default whenever possible, including refactors and fixes.
+This is the core of how we work, and the most violated rule when it goes
+wrong. Read it carefully.
 
-New modules get this header:
+### Division of labor
+
+- The user writes all real code: test bodies and implementations.
+- The collaborator provides only stubs (signatures, docstrings, spec
+  comments) and edit guidance. The collaborator does not write
+  implementations or fill test bodies unless the user explicitly asks, or
+  the work is pure mechanical busywork the user has delegated.
+
+### The loop
+
+TDD by default, including refactors and fixes. Each unit of work moves
+red, green, blue:
+
+- The collaborator provides a stub: the failing test's signature,
+  docstring, and spec comments, with a `...` body.
+- The user fills the test body and runs it, confirming it fails (red) for
+  the expected reason.
+- The collaborator confirms the diagnosis (right failure, right cause),
+  then provides the implementation stub: signatures and docstrings, no
+  body.
+- The user writes the implementation and confirms the test passes (green).
+- Either party may propose a refactor (blue); the user makes the change,
+  tests stay green.
+
+One atomic step per exchange. Confirm the current step before moving to
+the next.
+
+### Stub means stub
+
+A stub is signatures plus docstrings plus spec comments, with `...`
+bodies. Do not pre-fill implementations. Do not pre-fill dataclass
+fields. Provide the real thing only when the user asks, and not one step
+earlier. Repeatedly handing the user code they must delete and rewrite is
+the single worst way to waste their time.
+
+### Code block conventions
+
+- State a snippet's location in prose before the fence: the file path,
+  and the class or function if nested. Never put the path as a comment
+  inside the block; the user copies blocks verbatim.
+- Exception: a brand-new file starts with its project-root-relative path
+  as a literal first-line comment header, since that line is part of the
+  file. New modules use this header:
 
 ```python
 # src/depo/path/to/module.py
@@ -209,10 +192,21 @@ License: Apache-2.0
 """
 ```
 
-Include imports likely to be needed.
+- Include imports likely to be needed.
+- Delivered code carries no explanatory comments. The only comments
+  allowed are spec comments inside test stubs. Rationale and
+  edit-framing go in prose outside the block.
+- When the user is editing a file themselves, name the exact lines or
+  anchors to change and give only the replacement text framed by its
+  surrounding lines. Do not hand back a full rewritten block they must
+  diff by hand.
 
-Test modules include `TestClass` stubs with a docstring, spec comments
-describing what to test, and `...` as the body:
+### Test stub specifics
+
+- Test modules include a module docstring, imports, and `TestClass`
+  stubs.
+- Each test class and each test method gets a docstring AND spec
+  comments, not one or the other:
 
 ```python
 class TestSomething:
@@ -222,26 +216,56 @@ class TestSomething:
     ...
 ```
 
-Implementation modules include class, function, and method signatures
-with docstrings but no implementation unless explicitly asked.
-
-When updating an existing module, only include the stubs being added.
+- When updating an existing module, include only the stubs being added.
 
 ### Non-Python work (CSS, templates, HTML)
 
 Same stub-first principle. Describe what to add, which selectors or
 elements, and where in the file. For CSS, always provide full code
-blocks — descriptions cause errors and waste time. For templates,
+blocks; descriptions cause errors and waste time. For templates,
 describe the structure and classes unless explicitly asked for full
 markup. The user writes the actual code.
 
-### Improving this document **[static]**
+## Improving this document [static]
 
-This handoff is a living process document.
-At the end of each session,
-consider whether workflow friction could be reduced by
-updating the static sections.
-If a mistake keeps recurring,
-it belongs here as a convention or learning -
-not just a mental note.
-Future collaborators benefit from every improvement.
+This handoff is a living process document. At the end of each session,
+consider whether workflow friction could be reduced by updating the
+static sections. If a mistake keeps recurring, it belongs here as a
+convention, not just a mental note. Every improvement compounds for the
+next session.
+
+## Orientation [per-session]
+
+Rewrite fresh each session. Capture, concisely:
+
+- Date.
+- What just finished: the committed work this session, in commit order,
+  each with a one-line description of what it delivered. Name the branch.
+- What's in progress: anything uncommitted or mid-stream, and any
+  deliberate scope decisions a fresh reader would otherwise re-litigate
+  (e.g. a dependency intentionally deferred to a later PR).
+- What's next: the immediate next action, the branch it happens on, and a
+  link to the relevant planning block in mvp.md.
+
+## Layer status [per-session]
+
+Rewrite fresh each session. A nested list of the architectural layers
+touched this session and their state, so a fresh reader sees the blast
+radius at a glance.
+
+- One top-level item per layer or area touched (e.g. src/depo/cli,
+  tests/cli, doc/module)
+  - State: changed / added / unchanged
+  - The specific files touched and what changed in them, terse
+- Omit untouched layers, unless their unchanged state matters to the
+  next step
+
+## Known issues [per-session]
+
+Rewrite fresh each session. Anything broken, fragile, or deferred that
+the next session should know before touching the code.
+
+- Active bugs or rough edges, with where they live
+- Deferrals made this session, cross-referenced to the planning doc that
+  now tracks them
+- "None open" is a valid and good state to record

--- a/doc/planning/mvp.md
+++ b/doc/planning/mvp.md
@@ -32,54 +32,51 @@ Ordered by dependency. Each heading is roughly one PR.
 
 ### Login and session (Branch: `ft/login-session`)
 
-*Problem: users can be created and their passwords verified, but no
-request is ever recognized as logged in. Add a stateless signed-cookie
-session, a login route that verifies credentials and starts a session, a
-logout that ends it, and a single seam that reads the current user id
-from a request. Branch from `ft/credentials`. Assumes `ref/canonical-config`
-has landed (scalar defaults in `cli/defaults.py`, `DepoConfig` sources
-from them, `_coerce` typed field sets) and that `ft/credentials` provides
-`verify_password` and `ft/users-table` provides `get_user_by_email`. Out
-of scope: the `/upload` gate and `require_auth` as a route dependency
-(`ft/upload-gate`, which consumes the `get_current_uid` seam this PR
-builds); CSRF tokens (v1, tracked); server-side session store and
-revocation (post-MVP, tracked); email login and password reset (post-MVP).*
+*Problem: users can be created and their passwords verified, and session
+config infrastructure is in place, but no request is ever recognized as
+logged in. Wire the signed-cookie SessionMiddleware, a login route that
+verifies credentials and starts a session, a logout route that ends it,
+and a seam that reads the current user id from a request. Branch from
+`ft/login-config`, which provides `session_secret`, `session_https_only`,
+and the non-empty secret validation. Requires `verify_password` from
+`ft/credentials` and `get_user_by_email` from `ft/users-table`, both
+already merged. Out of scope: the `/upload` gate and `require_auth` as a
+route dependency (`ft/upload-gate`, which consumes the `get_current_uid`
+seam this PR builds); CSRF tokens (v1, tracked); server-side session
+store and revocation (post-MVP, tracked); email login and password reset
+(post-MVP).*
 
 #### Setup and gating test
 
-- [ ] Branch `ft/login-session` from `ft/credentials`.
-- [ ] Add a skipped integration test to `tests/web/test_routes.py` (new
+- [x] Branch `ft/login-session` from `ft/credentials`.
+- [x] Add a skipped integration test to `tests/web/test_routes.py` (new
       `TestLoginSession` class) asserting the end state: POSTing valid
       credentials to `/login` establishes a session such that a subsequent
       request is recognized as that user; bad credentials are rejected and
       re-render the form; `/logout` clears the session so a following
       request is unauthenticated. `@pytest.mark.skip` until the last unit.
-  - [ ] Commit: `Tst: Add skipped gating test for login and session`
+  - [x] Commit: `Tst: Add skipped gating test for login and session`
 
 #### TDD implementation
 
-**Add the itsdangerous dependency and session config**
-(`tests/cli/test_defaults.py`, `tests/cli/test_config.py`, make_config tests)
+*Note: the session config unit originally planned here was split into a
+separate `ft/login-config` PR. That PR delivered `session_secret` and
+`session_https_only` config fields, `_coerce_bool` with strict token
+validation, empty-secret validation in `load_config`, `make_config`
+factory secret default, and all associated test infrastructure. The
+remaining work below assumes `ft/login-config` is merged.*
+
+- [x] Commit: `Ft: Add session config fields and bool coercion`
+- [x] Commit: `Ref: Extract _coerce_bool and DRY out bool coercion tests`
+- [x] Commit: `Ref: DRY out TestLoadConfigEnv boilerplate`
+- [x] Commit: `Ref: DRY out TestLoadConfigToml and TestLoadConfigFlag`
+- [x] Commit: `Ft: Add non-empty session_secret default to make_config`
+
+**Add the itsdangerous dependency**
 
 - [ ] Add `itsdangerous` to `pyproject.toml` dependencies (Starlette
       `SessionMiddleware` requires it for cookie signing); sync the env.
-- [ ] Red: tests asserting `DepoConfig` exposes `session_secret` and
-      `session_https_only` sourced from `cli/defaults.py`; overrides (env
-      or TOML) resolve onto the config; an empty or missing
-      `session_secret` hard-fails rather than signing with a known value;
-      `session_https_only` coerces to bool and defaults False.
-- [ ] Add `DEFAULT_SESSION_SECRET = ""` (empty force-fail sentinel) and
-      `DEFAULT_SESSION_HTTPS_ONLY = False` (plain-HTTP LAN selfhost is the
-      MVP deployment; secure-only cookies would never be sent) to
-      `cli/defaults.py`; add `session_secret: str` and
-      `session_https_only: bool` fields to `DepoConfig` sourcing them; add
-      them to `_coerce` (secret as string, https_only to the bool set);
-      validate `session_secret` non-empty at resolution.
-- [ ] Update `make_config` in `tests/factories` to supply a non-empty
-      `session_secret` default so fixtures built from it pass the
-      non-empty validation; add a test that the default is present.
-- [ ] uv run ruff check && uv run pytest
-- [ ] Commit: `Ft: Add itsdangerous and session config`
+- [ ] Commit: `Chr: Add itsdangerous dependency`
 
 **Wire SessionMiddleware and the current-user seam**
 (`tests/web/test_app.py`, `tests/web/test_routes.py`)
@@ -141,11 +138,9 @@ revocation (post-MVP, tracked); email login and password reset (post-MVP).*
 - [ ] Update `doc/module/web.md` (session middleware, `get_current_uid`
       seam, login/logout routes), `doc/module/templates.md` (auth/login
       template), and add `/login` and `/logout` to the reserved-namespaces
-      list in `doc/design/routes.md`. Note the `session_secret` and
-      `session_https_only` config fields wherever config fields are
-      documented.
+      list in `doc/design/routes.md`.
 - [ ] uv run ruff check && uv run pytest
-- [ ] Commit: `Doc: ...`
+- [ ] Commit: `Doc: Update web and template docs for ft/login-session`
 
 #### PR
 
@@ -363,6 +358,14 @@ Ensure all hierarchy works in pure grayscale; color remains semantic only.
 - Replace empirical maxmem formula (256*n*r*p + 1MiB) in password.py
   with a principled bound once OpenSSL's internal buffer requirement is
   confirmed
+- Plan session secret management UX and dev/prod mode: a `DEPO_MODE`
+  config field (`dev`/`prod`), a `gen-secret` CLI command printing a
+  suitable random secret to stdout, and adjusted `load_config` behaviour
+  per mode (dev auto-generates an ephemeral secret with a warning; prod
+  keeps the hard-fail sentinel)
+- Write a deployment/ops doc covering required config for a running
+  instance: DEPO_SESSION_SECRET, WAL journal mode, store directory
+  setup, and recommended depo.toml fields
 
 ### Manual Testing
 

--- a/src/depo/cli/config.py
+++ b/src/depo/cli/config.py
@@ -129,6 +129,7 @@ def load_config(*, config_path: Path | None = None) -> DepoConfig:
 
     Raises:
         FileNotFoundError: If config_path provided but missing.
+        ConfigError: If session_secret is missing/empty or if any value fails coercion.
     """
     overrides: dict = {}
 
@@ -145,4 +146,10 @@ def load_config(*, config_path: Path | None = None) -> DepoConfig:
     # Env vars layer on top of everything
     overrides.update(_env_overrides())
 
-    return DepoConfig(**_coerce(overrides))
+    # Ensure session_secret is present and non-empty after all overrides
+    # NOTE: This is critical for security
+    cfg = DepoConfig(**_coerce(overrides))
+    if not cfg.session_secret.strip():
+        expected = "non-empty string"
+        raise ConfigError("session_secret", cfg.session_secret, expected=expected)
+    return cfg

--- a/src/depo/cli/config.py
+++ b/src/depo/cli/config.py
@@ -39,6 +39,9 @@ class DepoConfig:
     scrypt_n: int = defaults.SCRYPT_N
     scrypt_r: int = defaults.SCRYPT_R
     scrypt_p: int = defaults.SCRYPT_P
+    # Session secrets
+    session_secret: str = defaults.SESSION_SECRET
+    session_https_only: bool = defaults.SESSION_HTTPS_ONLY
 
 
 def _xdg_config_home() -> Path:
@@ -59,13 +62,27 @@ def _coerce(overrides: dict) -> dict:
     """Coerce string values from env/TOML to expected types."""
     int_fields = {"port", "max_size_bytes", "max_url_len", "min_code_len"}
     int_fields |= {"scrypt_n", "scrypt_r", "scrypt_p"}
+    bool_fields = {"session_https_only"}
     path_fields = {"db_path", "store_root"}
     out = {}
     for k, v in overrides.items():
         if k in int_fields:
             out[k] = int(v)
+
+        elif k in bool_fields:
+            if isinstance(v, bool):  # If already a bool (e.g. from TOML)
+                out[k] = v  # Use as-is, no coercion needed
+                continue  # Exit early for this key
+            cast = {"true": True, "false": False}
+            try:  # Try to coerce string to bool, case-insensitive
+                out[k] = cast[str(v).lower()]
+            except KeyError:
+                err = ConfigError(k, v, expected=["true", "false"])
+                raise err from None
+
         elif k in path_fields:
             out[k] = Path(v).expanduser()
+
         elif k == "log_level":  # Special case, needs to be a Severity enum member
             try:
                 out[k] = Severity[str(v).upper()]

--- a/src/depo/cli/config.py
+++ b/src/depo/cli/config.py
@@ -58,6 +58,24 @@ def _load_toml(path: Path) -> dict:
     return {}
 
 
+_TRUTHY_VALS = {"true", "yes", "on", "1", 1}
+_FALSY_VALS = {"false", "no", "off", "0", 0}
+
+
+def _coerce_bool(val: bool | int | str, field: str) -> bool:
+    """Coerce a config value to bool. Raises ConfigError if invalid."""
+    normalized = val
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        normalized = val.strip().lower()
+    if normalized in _TRUTHY_VALS:
+        return True
+    if normalized in _FALSY_VALS:
+        return False
+    raise ConfigError(field, val, expected=str(_TRUTHY_VALS | _FALSY_VALS))
+
+
 def _coerce(overrides: dict) -> dict:
     """Coerce string values from env/TOML to expected types."""
     int_fields = {"port", "max_size_bytes", "max_url_len", "min_code_len"}
@@ -70,15 +88,7 @@ def _coerce(overrides: dict) -> dict:
             out[k] = int(v)
 
         elif k in bool_fields:
-            if isinstance(v, bool):  # If already a bool (e.g. from TOML)
-                out[k] = v  # Use as-is, no coercion needed
-                continue  # Exit early for this key
-            cast = {"true": True, "false": False}
-            try:  # Try to coerce string to bool, case-insensitive
-                out[k] = cast[str(v).lower()]
-            except KeyError:
-                err = ConfigError(k, v, expected=["true", "false"])
-                raise err from None
+            out[k] = _coerce_bool(v, k)
 
         elif k in path_fields:
             out[k] = Path(v).expanduser()

--- a/src/depo/cli/defaults.py
+++ b/src/depo/cli/defaults.py
@@ -28,6 +28,10 @@ SCRYPT_N = 2**16
 SCRYPT_R = 8
 SCRYPT_P = 1
 
+# Session Secrets
+SESSION_SECRET = ""  # Force-fail sentinel, override in production to be safe or fail
+SESSION_HTTPS_ONLY = False  # Default False, easier local development, override in prod
+
 
 def default_store_dir() -> Path:
     """Return XDG_DATA_HOME/depo/store if set, else ./store for containerized deploys"""

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -73,6 +73,8 @@ class TestDepoConfig:
             ("scrypt_n", int, False, defaults.SCRYPT_N),
             ("scrypt_r", int, False, defaults.SCRYPT_R),
             ("scrypt_p", int, False, defaults.SCRYPT_P),
+            ("session_secret", str, False, defaults.SESSION_SECRET),
+            ("session_https_only", bool, False, defaults.SESSION_HTTPS_ONLY),
         ],
     )
     def test_simple_fields(self, name, typ, required, default):
@@ -231,6 +233,36 @@ class TestLoadConfigEnv:
         assert cfg.scrypt_n == 4096
         assert cfg.scrypt_r == 4
         assert cfg.scrypt_p == 2
+
+    def test_env_session_https_only_true(self, monkeypatch, tmp_path):
+        """DEPO_SESSION_HTTPS_ONLY truthy string coerces to True."""
+        self._clear_depo_env(monkeypatch)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DEPO_SESSION_HTTPS_ONLY", "true")
+        assert load_config().session_https_only is True
+
+    def test_env_session_https_only_false(self, monkeypatch, tmp_path):
+        """A falsy string coerces to False, not the bool('false')=True trap."""
+        self._clear_depo_env(monkeypatch)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DEPO_SESSION_HTTPS_ONLY", "false")
+        assert load_config().session_https_only is False
+
+    def test_env_session_https_only_invalid_raises(self, monkeypatch, tmp_path):
+        """An unrecognized value raises ConfigError."""
+        # should clear env, point XDG at empty, chdir tmp
+        # should setenv DEPO_SESSION_HTTPS_ONLY to "banana"
+        # should assert load_config() raises ConfigError
+        self._clear_depo_env(monkeypatch)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("DEPO_SESSION_HTTPS_ONLY", "fooBAR")
+        with pytest.raises(ConfigError) as e:
+            load_config()
+        assert e.value.key == "session_https_only"
+        assert e.value.value == "fooBAR"
 
 
 class TestLoadConfigFlag:

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -142,6 +142,7 @@ class TestLoadConfigToml:
         _clear_depo_env(monkeypatch)
         toml_cfgs = {"host": "0.0.0.0", "port": 9000}
         _write_toml(tmp_path / "xdg/depo/config.toml", **toml_cfgs)
+        monkeypatch.setenv("DEPO_SESSION_SECRET", "test-secret")
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
         monkeypatch.chdir(tmp_path)
         cfg = load_config()
@@ -156,6 +157,7 @@ class TestLoadConfigToml:
         (xdg_cfg / "depo").mkdir(parents=True)
         (xdg_cfg / "depo" / "config.toml").write_text("port = 9000\n")
         monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
+        monkeypatch.setenv("DEPO_SESSION_SECRET", "test-secret")
         # Local says port 7000
         workdir = tmp_path / "project"
         workdir.mkdir()
@@ -166,6 +168,7 @@ class TestLoadConfigToml:
 
     def test_partial_toml_preserves_defaults(self, monkeypatch, tmp_path):
         _clear_depo_env(monkeypatch)
+        monkeypatch.setenv("DEPO_SESSION_SECRET", "test-secret")
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
         workdir = tmp_path / "proj"
         workdir.mkdir()
@@ -180,6 +183,7 @@ class TestLoadConfigToml:
         """log_level resolves from a TOML config file."""
         _clear_depo_env(monkeypatch)
         _write_toml(tmp_path / "xdg/depo/config.toml", log_level="DEBUG")
+        monkeypatch.setenv("DEPO_SESSION_SECRET", "test-secret")
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
         monkeypatch.chdir(tmp_path)
         assert load_config().log_level == Severity.DEBUG
@@ -192,6 +196,7 @@ class TestLoadConfigEnv:
     def _isolate_env(self, monkeypatch, tmp_path):
         """Clear DEPO_* env.vars, point XDG_CONFIG_HOME to tmp_path and chdir to it"""
         _clear_depo_env(monkeypatch)
+        monkeypatch.setenv("DEPO_SESSION_SECRET", "test-secret")
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
         monkeypatch.chdir(tmp_path)
 
@@ -253,6 +258,13 @@ class TestLoadConfigEnv:
         with pytest.raises(ConfigError):
             load_config()
 
+    def test_empty_session_secret_raises(self, monkeypatch):
+        """An empty or missing SESSION_SECRET raises ConfigError at resolution."""
+        _set_depo_env(monkeypatch, session_secret="")
+        with pytest.raises(ConfigError) as e:
+            load_config()
+        assert e.value.key == "session_secret"
+
 
 class TestLoadConfigFlag:
     """Tests for config_path parameter (--config flag)."""
@@ -260,6 +272,7 @@ class TestLoadConfigFlag:
     def test_config_path_overrides_toml_chain(self, monkeypatch, tmp_path):
         _clear_depo_env(monkeypatch)
         _write_toml(tmp_path / "xdg/depo/config.toml", port=9000)
+        monkeypatch.setenv("DEPO_SESSION_SECRET", "test-secret")
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
         monkeypatch.chdir(tmp_path)
         explicit = tmp_path / "custom.toml"
@@ -278,6 +291,7 @@ class TestLoadConfigFlag:
         _clear_depo_env(monkeypatch)
         explicit = tmp_path / "custom.toml"
         _write_toml(explicit, port=1234)
+        monkeypatch.setenv("DEPO_SESSION_SECRET", "test-secret")
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
         monkeypatch.chdir(tmp_path)
         monkeypatch.setenv("DEPO_HOST", "10.0.0.5")

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -7,8 +7,6 @@ Created: 2026-02-06
 License: Apache-2.0
 """
 
-# TODO: A ton of these can be refactored to use make_config factory
-
 import os
 from pathlib import Path
 
@@ -16,7 +14,7 @@ import pytest
 from tests.helpers.assertions import assert_field
 
 from depo.cli import defaults
-from depo.cli.config import DepoConfig, load_config
+from depo.cli.config import DepoConfig, _coerce_bool, load_config
 from depo.cli.defaults import _XDG_DATA_HOME, default_db_path, default_store_dir
 from depo.util.errors import ConfigError, Severity
 
@@ -108,6 +106,33 @@ class TestDepoConfig:
         assert cfg.port == 3000
         assert cfg.max_size_bytes == defaults.MAX_SIZE_BYTES
         assert cfg.max_url_len == defaults.MAX_URL_LEN
+
+
+class TestCoerceBool:
+    """Tests for the _coerce_bool helper function."""
+
+    def test_native_bool_passthrough(self):
+        """Native bools are returned unchanged."""
+        assert _coerce_bool(True, "test") is True
+        assert _coerce_bool(False, "test") is False
+
+    @pytest.mark.parametrize("val", ["true", "True", "TRUE", "1", "yes", "on", "1", 1])
+    def test_truthy_tokens(self, val):
+        """Recognized truthy tokens coerce to True, case-insensitive."""
+        assert _coerce_bool(val, "test") is True
+
+    @pytest.mark.parametrize("token", ["false", "False", "FALSE", "no", "off", "0", 0])
+    def test_falsy_tokens(self, token):
+        """Recognized falsy tokens coerce to False, case-insensitive."""
+        assert _coerce_bool(token, "test") is False
+
+    @pytest.mark.parametrize("val", ["banana", "truth", 42, -1, 99])
+    def test_invalid_raises(self, val):
+        """An unrecognized token raises ConfigError naming the key and bad value."""
+        with pytest.raises(ConfigError) as e:
+            _coerce_bool(val, "some_field")
+        assert e.value.key == "some_field"
+        assert e.value.value == val
 
 
 class TestLoadConfigToml:
@@ -217,23 +242,16 @@ class TestLoadConfigEnv:
         assert config.scrypt_r == 4
         assert config.scrypt_p == 2
 
-    def test_env_session_https_only_true(self, monkeypatch):
-        """DEPO_SESSION_HTTPS_ONLY truthy string coerces to True."""
-        _set_depo_env(monkeypatch, SESSION_HTTPS_ONLY="true")
+    def test_env_session_https_only_coerces(self, monkeypatch):
+        """Bool env var coerces and lands correctly on config."""
+        _set_depo_env(monkeypatch, SESSION_HTTPS_ONLY="yEs")
         assert load_config().session_https_only is True
 
-    def test_env_session_https_only_false(self, monkeypatch):
-        """A falsy string coerces to False, not the bool('false')=True trap."""
-        _set_depo_env(monkeypatch, SESSION_HTTPS_ONLY="false")
-        assert load_config().session_https_only is False
-
-    def test_env_session_https_only_invalid_raises(self, monkeypatch, tmp_path):
-        """An unrecognized value raises ConfigError."""
-        _set_depo_env(monkeypatch, SESSION_HTTPS_ONLY="fooBAR")
-        with pytest.raises(ConfigError) as e:
+    def test_env_session_https_only_invalid_propagates(self, monkeypatch):
+        """Invalid bool env var propagates ConfigError through load_config."""
+        _set_depo_env(monkeypatch, SESSION_HTTPS_ONLY="not_a_boolean")
+        with pytest.raises(ConfigError):
             load_config()
-        assert e.value.key == "session_https_only"
-        assert e.value.value == "fooBAR"
 
 
 class TestLoadConfigFlag:

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -21,10 +21,17 @@ from depo.cli.defaults import _XDG_DATA_HOME, default_db_path, default_store_dir
 from depo.util.errors import ConfigError, Severity
 
 
-def _clear_depo_env(monkeypatch):
+def _clear_depo_env(monkeypatch) -> None:
     for key in list(os.environ):
         if key.startswith("DEPO_"):
             monkeypatch.delenv(key)
+
+
+def _set_depo_env(monkeypatch, **kwargs) -> None:
+    """Set DEPO_* env vars from kwargs, names uppercased and prefixed.
+    basically: setenv "DEPO_${kwargs:key}"="${kwargs[value]}" """
+    for key, val in kwargs.items():
+        monkeypatch.setenv(f"DEPO_{key.upper()}", str(val))
 
 
 def _write_toml(path: Path, **kwargs) -> None:
@@ -156,109 +163,73 @@ class TestLoadConfigToml:
 class TestLoadConfigEnv:
     """Tests for DEPO_* environment variable overrides."""
 
-    def _clear_depo_env(self, monkeypatch):
-        for key in list(os.environ):
-            if key.startswith("DEPO_"):
-                monkeypatch.delenv(key)
+    @pytest.fixture(autouse=True)
+    def _isolate_env(self, monkeypatch, tmp_path):
+        """Clear DEPO_* env.vars, point XDG_CONFIG_HOME to tmp_path and chdir to it"""
+        _clear_depo_env(monkeypatch)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+        monkeypatch.chdir(tmp_path)
 
     def test_env_overrides_toml(self, monkeypatch, tmp_path):
-        self._clear_depo_env(monkeypatch)
-        workdir = tmp_path / "proj"
-        workdir.mkdir()
-        _write_toml(workdir / "depo.toml", port=7000)
-        monkeypatch.chdir(workdir)
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
-        monkeypatch.setenv("DEPO_PORT", "5555")
-        cfg = load_config()
-        assert cfg.port == 5555
+        """Env.vars overrides any TOML config of respective config key-value pair"""
+        _write_toml(tmp_path / "depo.toml", port=7000)
+        _set_depo_env(monkeypatch, PORT="5555")
+        assert load_config().port == 5555
 
-    def test_env_host(self, monkeypatch, tmp_path):
-        self._clear_depo_env(monkeypatch)
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setenv("DEPO_HOST", "192.168.1.1")
-        cfg = load_config()
-        assert cfg.host == "192.168.1.1"
+    def test_env_host(self, monkeypatch):
+        """DEPO_HOST env var overrides the default host."""
+        _set_depo_env(monkeypatch, HOST="192.168.1.1")
+        assert load_config().host == "192.168.1.1"
 
-    def test_env_path_expansion(self, monkeypatch, tmp_path):
-        self._clear_depo_env(monkeypatch)
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setenv("DEPO_DB_PATH", "~/my-depo/data.db")
-        cfg = load_config()
-        assert cfg.db_path == Path.home() / "my-depo/data.db"
+    def test_env_path_tilda_expansion(self, monkeypatch):
+        """Path configs correctly coerces tildas to home path prefixes"""
+        _set_depo_env(monkeypatch, db_path="~/test.db")
+        assert load_config().db_path == Path.home() / "test.db"
 
-    def test_env_int_coercion(self, monkeypatch, tmp_path):
-        self._clear_depo_env(monkeypatch)
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
-        monkeypatch.chdir(tmp_path)
+    def test_env_int_coercion(self, monkeypatch):
+        """Int values are correctly cast from string config values"""
         monkeypatch.setenv("DEPO_MAX_SIZE_BYTES", "5242880")
-        cfg = load_config()
-        assert cfg.max_size_bytes == 5_242_880
+        assert load_config().max_size_bytes == 5_242_880
 
-    def test_env_log_level(self, monkeypatch, tmp_path):
+    def test_env_log_level(self, monkeypatch):
         """DEPO_LOG_LEVEL overrides the default log_level."""
-        self._clear_depo_env(monkeypatch)
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setenv("DEPO_LOG_LEVEL", "DEBUG")
+        _set_depo_env(monkeypatch, log_level="DEBUG")
         assert load_config().log_level == Severity.DEBUG
 
-    def test_env_log_level_case_insensitive(self, monkeypatch, tmp_path):
+    def test_env_log_level_case_insensitive(self, monkeypatch):
         """A lowercase DEPO_LOG_LEVEL still resolves to a Severity member."""
-        self._clear_depo_env(monkeypatch)
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setenv("DEPO_LOG_LEVEL", "deBug")
+        _set_depo_env(monkeypatch, LOG_level="deBug")
         assert load_config().log_level == Severity.DEBUG
 
-    def test_env_log_level_invalid_raises(self, monkeypatch, tmp_path):
+    def test_env_log_level_invalid_raises(self, monkeypatch):
         """An unknown DEPO_LOG_LEVEL raises ConfigError."""
-        self._clear_depo_env(monkeypatch)
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setenv("DEPO_LOG_LEVEL", "BANANA")
-        with pytest.raises(ConfigError):
+        _set_depo_env(monkeypatch, log_level="BANANA")
+        with pytest.raises(ConfigError) as e:
             load_config()
+        assert e.value.key == "log_level"
+        assert e.value.value == "BANANA"
 
-    def test_env_scrypt_int_coercion(self, monkeypatch, tmp_path):
+    def test_env_scrypt_int_coercion(self, monkeypatch):
         """DEPO_SCRYPT_N/R/P env vars coerce to int on DepoConfig."""
-        self._clear_depo_env(monkeypatch)
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setenv("DEPO_SCRYPT_N", "4096")
-        monkeypatch.setenv("DEPO_SCRYPT_R", "4")
-        monkeypatch.setenv("DEPO_SCRYPT_P", "2")
-        cfg = load_config()
-        assert cfg.scrypt_n == 4096
-        assert cfg.scrypt_r == 4
-        assert cfg.scrypt_p == 2
+        _set_depo_env(monkeypatch, SCRYPT_N=4096, SCRYPT_R=4, SCRYPT_P=2)
+        config = load_config()
+        assert config.scrypt_n == 4096
+        assert config.scrypt_r == 4
+        assert config.scrypt_p == 2
 
-    def test_env_session_https_only_true(self, monkeypatch, tmp_path):
+    def test_env_session_https_only_true(self, monkeypatch):
         """DEPO_SESSION_HTTPS_ONLY truthy string coerces to True."""
-        self._clear_depo_env(monkeypatch)
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setenv("DEPO_SESSION_HTTPS_ONLY", "true")
+        _set_depo_env(monkeypatch, SESSION_HTTPS_ONLY="true")
         assert load_config().session_https_only is True
 
-    def test_env_session_https_only_false(self, monkeypatch, tmp_path):
+    def test_env_session_https_only_false(self, monkeypatch):
         """A falsy string coerces to False, not the bool('false')=True trap."""
-        self._clear_depo_env(monkeypatch)
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setenv("DEPO_SESSION_HTTPS_ONLY", "false")
+        _set_depo_env(monkeypatch, SESSION_HTTPS_ONLY="false")
         assert load_config().session_https_only is False
 
     def test_env_session_https_only_invalid_raises(self, monkeypatch, tmp_path):
         """An unrecognized value raises ConfigError."""
-        # should clear env, point XDG at empty, chdir tmp
-        # should setenv DEPO_SESSION_HTTPS_ONLY to "banana"
-        # should assert load_config() raises ConfigError
-        self._clear_depo_env(monkeypatch)
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setenv("DEPO_SESSION_HTTPS_ONLY", "fooBAR")
+        _set_depo_env(monkeypatch, SESSION_HTTPS_ONLY="fooBAR")
         with pytest.raises(ConfigError) as e:
             load_config()
         assert e.value.key == "session_https_only"
@@ -268,13 +239,8 @@ class TestLoadConfigEnv:
 class TestLoadConfigFlag:
     """Tests for config_path parameter (--config flag)."""
 
-    def _clear_depo_env(self, monkeypatch):
-        for key in list(os.environ):
-            if key.startswith("DEPO_"):
-                monkeypatch.delenv(key)
-
     def test_config_path_overrides_toml_chain(self, monkeypatch, tmp_path):
-        self._clear_depo_env(monkeypatch)
+        _clear_depo_env(monkeypatch)
         _write_toml(tmp_path / "xdg/depo/config.toml", port=9000)
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
         monkeypatch.chdir(tmp_path)
@@ -284,14 +250,14 @@ class TestLoadConfigFlag:
         assert cfg.port == 1234
 
     def test_missing_config_path_raises(self, monkeypatch, tmp_path):
-        self._clear_depo_env(monkeypatch)
+        _clear_depo_env(monkeypatch)
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
         monkeypatch.chdir(tmp_path)
         with pytest.raises(FileNotFoundError):
             load_config(config_path=tmp_path / "nonexistent.toml")
 
     def test_env_layers_on_config_path(self, monkeypatch, tmp_path):
-        self._clear_depo_env(monkeypatch)
+        _clear_depo_env(monkeypatch)
         explicit = tmp_path / "custom.toml"
         _write_toml(explicit, port=1234)
         monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -32,6 +32,14 @@ def _set_depo_env(monkeypatch, **kwargs) -> None:
         monkeypatch.setenv(f"DEPO_{key.upper()}", str(val))
 
 
+def _isolate_config_env(monkeypatch, tmp_path) -> None:
+    """Clear DEPO_* vars, set a valid session secret, point XDG to tmp_path, chdir."""
+    _clear_depo_env(monkeypatch)
+    _set_depo_env(monkeypatch, session_secret="test-secret")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+    monkeypatch.chdir(tmp_path)
+
+
 def _write_toml(path: Path, **kwargs) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     lines = []
@@ -138,54 +146,38 @@ class TestCoerceBool:
 class TestLoadConfigToml:
     """Tests for TOML file resolution chain."""
 
+    @pytest.fixture(autouse=True)
+    def _isolate_env(self, monkeypatch, tmp_path):
+        _isolate_config_env(monkeypatch, tmp_path)
+
     def test_xdg_config_overrides_defaults(self, monkeypatch, tmp_path):
-        _clear_depo_env(monkeypatch)
+        """XDG config.toml values override DepoConfig defaults."""
         toml_cfgs = {"host": "0.0.0.0", "port": 9000}
-        _write_toml(tmp_path / "xdg/depo/config.toml", **toml_cfgs)
-        monkeypatch.setenv("DEPO_SESSION_SECRET", "test-secret")
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
-        monkeypatch.chdir(tmp_path)
+        _write_toml(tmp_path / "depo/config.toml", **toml_cfgs)
         cfg = load_config()
         assert cfg.host == "0.0.0.0"
         assert cfg.port == 9000
         assert cfg.max_size_bytes == defaults.MAX_SIZE_BYTES
 
     def test_local_toml_overrides_xdg(self, monkeypatch, tmp_path):
-        _clear_depo_env(monkeypatch)
-        # XDG says port 9000
-        xdg_cfg = tmp_path / "xdg"
-        (xdg_cfg / "depo").mkdir(parents=True)
-        (xdg_cfg / "depo" / "config.toml").write_text("port = 9000\n")
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_cfg))
-        monkeypatch.setenv("DEPO_SESSION_SECRET", "test-secret")
-        # Local says port 7000
+        """Local depo.toml port overrides the XDG config.toml port."""
+        _write_toml(tmp_path / "depo/config.toml", port=9000)
         workdir = tmp_path / "project"
         workdir.mkdir()
-        (workdir / "depo.toml").write_text("port = 7000\n")
+        _write_toml(workdir / "depo.toml", port=7000)
         monkeypatch.chdir(workdir)
-        cfg = load_config()
-        assert cfg.port == 7000
+        assert load_config().port == 7000
 
-    def test_partial_toml_preserves_defaults(self, monkeypatch, tmp_path):
-        _clear_depo_env(monkeypatch)
-        monkeypatch.setenv("DEPO_SESSION_SECRET", "test-secret")
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
-        workdir = tmp_path / "proj"
-        workdir.mkdir()
-        (workdir / "depo.toml").write_text('host = "10.0.0.1"\n')
-        monkeypatch.chdir(workdir)
-        cfg = load_config()
-        assert cfg.host == "10.0.0.1"
-        assert cfg.port == 8765
-        assert cfg.max_url_len == defaults.MAX_URL_LEN
+    def test_partial_toml_preserves_defaults(self, tmp_path):
+        """A partial TOML overrides only named fields, defaults fill the rest."""
+        _write_toml(tmp_path / "depo.toml", host="10.0.0.1")
+        assert load_config().host == "10.0.0.1"
+        assert load_config().port == defaults.PORT
+        assert load_config().max_url_len == defaults.MAX_URL_LEN
 
-    def test_toml_log_level(self, monkeypatch, tmp_path):
+    def test_toml_log_level(self, tmp_path):
         """log_level resolves from a TOML config file."""
-        _clear_depo_env(monkeypatch)
-        _write_toml(tmp_path / "xdg/depo/config.toml", log_level="DEBUG")
-        monkeypatch.setenv("DEPO_SESSION_SECRET", "test-secret")
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
-        monkeypatch.chdir(tmp_path)
+        _write_toml(tmp_path / "depo/config.toml", log_level="DEBUG")
         assert load_config().log_level == Severity.DEBUG
 
 
@@ -195,10 +187,7 @@ class TestLoadConfigEnv:
     @pytest.fixture(autouse=True)
     def _isolate_env(self, monkeypatch, tmp_path):
         """Clear DEPO_* env.vars, point XDG_CONFIG_HOME to tmp_path and chdir to it"""
-        _clear_depo_env(monkeypatch)
-        monkeypatch.setenv("DEPO_SESSION_SECRET", "test-secret")
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-        monkeypatch.chdir(tmp_path)
+        _isolate_config_env(monkeypatch, tmp_path)
 
     def test_env_overrides_toml(self, monkeypatch, tmp_path):
         """Env.vars overrides any TOML config of respective config key-value pair"""
@@ -269,32 +258,24 @@ class TestLoadConfigEnv:
 class TestLoadConfigFlag:
     """Tests for config_path parameter (--config flag)."""
 
-    def test_config_path_overrides_toml_chain(self, monkeypatch, tmp_path):
-        _clear_depo_env(monkeypatch)
-        _write_toml(tmp_path / "xdg/depo/config.toml", port=9000)
-        monkeypatch.setenv("DEPO_SESSION_SECRET", "test-secret")
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "xdg"))
-        monkeypatch.chdir(tmp_path)
-        explicit = tmp_path / "custom.toml"
-        _write_toml(explicit, port=1234)
-        cfg = load_config(config_path=explicit)
-        assert cfg.port == 1234
+    @pytest.fixture(autouse=True)
+    def _isolate_env(self, monkeypatch, tmp_path):
+        _isolate_config_env(monkeypatch, tmp_path)
 
-    def test_missing_config_path_raises(self, monkeypatch, tmp_path):
-        _clear_depo_env(monkeypatch)
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
-        monkeypatch.chdir(tmp_path)
+    def test_config_path_overrides_toml_chain(self, tmp_path):
+        """Explicit config_path overrides the TOML resolution chain."""
+        _write_toml(tmp_path / "depo/config.toml", port=9000)
+        _write_toml(tmp_path / "custom.toml", port=1234)
+        assert load_config(config_path=tmp_path / "custom.toml").port == 1234
+
+    def test_missing_config_path_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):
             load_config(config_path=tmp_path / "nonexistent.toml")
 
     def test_env_layers_on_config_path(self, monkeypatch, tmp_path):
-        _clear_depo_env(monkeypatch)
         explicit = tmp_path / "custom.toml"
         _write_toml(explicit, port=1234)
-        monkeypatch.setenv("DEPO_SESSION_SECRET", "test-secret")
-        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / "empty"))
-        monkeypatch.chdir(tmp_path)
-        monkeypatch.setenv("DEPO_HOST", "10.0.0.5")
+        _set_depo_env(monkeypatch, host="10.0.0.5")
         cfg = load_config(config_path=explicit)
         assert cfg.port == 1234
         assert cfg.host == "10.0.0.5"

--- a/tests/cli/test_defaults.py
+++ b/tests/cli/test_defaults.py
@@ -43,3 +43,12 @@ class TestScryptDefaults:
         assert defaults.SCRYPT_N == 2**16
         assert defaults.SCRYPT_R == 8
         assert defaults.SCRYPT_P == 1
+
+
+class TestSessionDefaults:
+    """Session signing defaults exist with safe values."""
+
+    def test_session_constants(self):
+        """SESSION_SECRET is the empty force-fail sentinel, SESSION_HTTPS_ONLY=False."""
+        assert defaults.SESSION_SECRET == ""
+        assert defaults.SESSION_HTTPS_ONLY is False

--- a/tests/factories/__init__.py
+++ b/tests/factories/__init__.py
@@ -63,7 +63,11 @@ def make_config(p: Path, **overrides: Any) -> DepoConfig:
     Keyword overrides replace any default field on the returned config.
     Used internally by make_client.
     """
-    base = {"db_path": p / "data" / "depo.db", "store_root": p / "store"}
+    base = {
+        "db_path": p / "data" / "depo.db",
+        "store_root": p / "store",
+        "session_secret": "test-session-secret",
+    }
     return DepoConfig(**{**base, **overrides})
 
 

--- a/tests/factories/test_factories.py
+++ b/tests/factories/test_factories.py
@@ -23,6 +23,10 @@ class TestMakeConfig:
         assert make_config(tmp_path, max_size_bytes=1).max_size_bytes == 1
         assert make_config(tmp_path, log_level="INFO").log_level == "INFO"
 
+    def test_default_session_secret_present(self, tmp_path: Path) -> None:
+        """make_config provides a non-empty session_secret by default."""
+        assert make_config(tmp_path).session_secret != ""
+
 
 class TestMakeUser:
     """Tests for the make_user factory."""

--- a/tests/web/test_routes.py
+++ b/tests/web/test_routes.py
@@ -8,6 +8,8 @@ Created: 2026-02-23
 License: Apache-2.0
 """
 
+import pytest
+
 
 class TestRouteRegistration:
     """Fixed-path routes are not swallowed by /{code} wildcard."""
@@ -55,3 +57,40 @@ class TestRootRedirect:
         resp = t_client.get(url="/", follow_redirects=False)
         assert resp.status_code == 302
         assert resp.headers.get("location") == "/upload"
+
+
+@pytest.mark.skip(reason="enabled at end of ft/login-session")
+class TestLoginSession:
+    """End-to-end login, session, and logout over HTTP.
+
+    Probes the session lifecycle via the t_client cookie jar; no
+    authenticated-only route exists until ft/upload-gate, so value-level
+    uid recognition is left to the get_current_uid seam unit test.
+    """
+
+    def test_valid_login_starts_session(self, t_client):
+        """POST /login with valid creds 302s and sets a session cookie."""
+        # should seed a user with a known password
+        # should POST email + password to /login with follow_redirects=False
+        # should get 302
+        # should find the session cookie present in the client jar
+        _ = t_client
+        ...
+
+    def test_bad_credentials_rejected(self, t_client):
+        """POST /login with a wrong password re-renders the form, no session."""
+        # should seed a user with a known password
+        # should POST email + wrong password to /login
+        # should re-render the login form (200, html, error surfaced in body)
+        # should set no session cookie
+        _ = t_client
+        ...
+
+    def test_logout_clears_session(self, t_client):
+        """GET /logout 302s and clears the session cookie."""
+        # should seed a user and log in
+        # should GET /logout with follow_redirects=False
+        # should get 302
+        # should find the session cookie cleared in the client jar
+        _ = t_client
+        ...


### PR DESCRIPTION
Config infrastructure for auth sessions, split out from the original
ft/login-session plan so the session middleware and routes land on a
clean config base.

## What this delivers

- SESSION_SECRET and SESSION_HTTPS_ONLY defaults in cli/defaults.py
- session_secret and session_https_only fields on DepoConfig
- _coerce_bool helper: native bool passthrough, case-insensitive string
  tokens (true/yes/on/1, false/no/off/0), int 0/1, ConfigError on
  anything unrecognized, original value preserved in the error
- Empty session_secret validation in load_config: the "" default is a
  force-fail sentinel so the app refuses to boot without an
  operator-supplied secret
- make_config factory supplies a non-empty secret so test-built apps are
  signable

## Test work

- New TestCoerceBool covering the helper directly
- DRY-up of TestLoadConfigEnv, TestLoadConfigToml, and
  TestLoadConfigFlag via _set_depo_env and a shared _isolate_config_env
  helper behind autouse fixtures

## Notes

- itsdangerous is intentionally NOT added here; it belongs in
  ft/login-session where SessionMiddleware first uses it
- The skipped TestLoginSession gating test rides along; it unskips at
  the end of ft/login-session
- Session secret management UX and a dev/prod mode flag are deferred to
  pre-MVP housecleaning in mvp.md

Suite green at 701 passed, 3 skipped.
