### PR TITLE
Ft: Login and session

### DIFF
--- a/doc/design/routes.md
+++ b/doc/design/routes.md
@@ -76,6 +76,8 @@ These top-level prefixes are reserved and must not conflict with short-codes:
 
 - `/upload`
 - `/health`
+- `/login`
+- `/logout`
 
 ### Reserved Namespaces - Post-MVP additions
 

--- a/doc/module/templates.md
+++ b/doc/module/templates.md
@@ -35,6 +35,8 @@ base.html
 │   ├── page.html
 │   ├── formats.html
 │   └── script.html
+├── auth/
+│   └── login.html           # Login form (extends base.html)
 ├── theme.html
 ├── info/page.html
 │   ├── info/link.html

--- a/doc/module/web.md
+++ b/doc/module/web.md
@@ -5,7 +5,8 @@ Depends on service/, repo/, storage/, model/, cli/.
 
 ## app.py
 
-Application factory and logging setup. Wires dependencies from DepoConfig.
+Application factory and logging setup.
+Wires dependencies from DepoConfig.
 
 ### Functions
 
@@ -22,6 +23,8 @@ Registers the `unhandled` boundary via
 catch non-DepoError exceptions that escape routes.
 Mounts static files from `src/depo/static/`.
 SQLite uses `check_same_thread=False` for async handler compatibility.
+Also wires `SessionMiddleware` (itsdangerous signed cookies) using
+`config.session_secret` and `config.session_https_only`.
 
 `configure_logging` sets the `depo` logger level and attaches a text handler.
 `app_factory` calls it as its first step, driven by `config.log_level`.
@@ -30,7 +33,7 @@ SQLite uses `check_same_thread=False` for async handler compatibility.
 
 Route package. Domain routers in sub-modules, wiring in `__init__.py`.
 
-### __init__.py
+### init.py
 
 Wires domain routers and registers fixed-path handlers.
 Fixed-path decorators before `include_router` calls.
@@ -41,6 +44,23 @@ Wildcard shortcode router included last.
 | GET | `/` | `root_redirect()` | 302 redirect to `/upload` |
 | GET | `/health` | `health()` | Liveness probe |
 | POST | `/` | `upload()` | Alias, forwards to upload dispatcher |
+
+### auth.py
+
+Authentication router. Login and logout routes.
+
+| Method | Path | Handler | Description |
+|--------|------|---------|-------------|
+| GET | `/login` | `page_login()` | Render login form; redir. `/` if auth'd |
+| POST | `/login` | `handle_login()` | *`^`* |
+| GET | `/logout` | `handle_logout()` | Clears session and redirects to `/` |
+
+>`^`: Check credentials, start session on ack, re-renders form with error if fail
+
+`_render_login(request, error)` unifies all login-page renders.
+GET and both failure paths call it; `error` is `None` on the GET and
+an `AuthenticationError` instance on failure.
+Both failure paths (unknown email, wrong password) produce an identical 401 surface.
 
 ### shortcode.py
 
@@ -136,9 +156,14 @@ FastAPI dependency providers via `Depends()`.
 get_repo(request) -> SqliteRepository
 get_storage(request) -> StorageBackend
 get_orchestrator(request) -> IngestOrchestrator
+get_current_uid(request) -> int | None
 ```
 
 Thin getters pulling from `request.app.state`.
+
+`get_current_uid` reads request.session.get("uid");
+the only function in the web layer that touches `request.session` directly.
+`require_auth` in `ft/upload-gate` calls it to enforce authenticated access.
 
 ## Templates
 

--- a/doc/planning/handoff.md
+++ b/doc/planning/handoff.md
@@ -28,7 +28,11 @@ Before ending a session:
 - Carry static sections forward, with any updates made during the session
 - Trim completed items from planning docs
 - Record deferrals in the appropriate planning doc, not just here
-- Present the finished handoff for the user to persist
+- Output the finished handoff as the complete document in a single
+  markdown code fence: every static section reproduced verbatim and every
+  per-session section filled in with this session's content. "Carry
+  forward" means reproduce in full, not omit. The user copies the whole
+  fence to persist it.
 
 ## Test fixtures and factories [static]
 

--- a/doc/planning/mvp.md
+++ b/doc/planning/mvp.md
@@ -30,122 +30,6 @@ service, repo, and storage. Dedupe by content hash.
 
 Ordered by dependency. Each heading is roughly one PR.
 
-### Login and session (Branch: `ft/login-session`)
-
-*Problem: users can be created and their passwords verified, and session
-config infrastructure is in place, but no request is ever recognized as
-logged in. Wire the signed-cookie SessionMiddleware, a login route that
-verifies credentials and starts a session, a logout route that ends it,
-and a seam that reads the current user id from a request. Branch from
-`ft/login-config`, which provides `session_secret`, `session_https_only`,
-and the non-empty secret validation. Requires `verify_password` from
-`ft/credentials` and `get_user_by_email` from `ft/users-table`, both
-already merged. Out of scope: the `/upload` gate and `require_auth` as a
-route dependency (`ft/upload-gate`, which consumes the `get_current_uid`
-seam this PR builds); CSRF tokens (v1, tracked); server-side session
-store and revocation (post-MVP, tracked); email login and password reset
-(post-MVP).*
-
-#### Setup and gating test
-
-- [x] Branch `ft/login-session` from `ft/credentials`.
-- [x] Add a skipped integration test to `tests/web/test_routes.py` (new
-      `TestLoginSession` class) asserting the end state: POSTing valid
-      credentials to `/login` establishes a session such that a subsequent
-      request is recognized as that user; bad credentials are rejected and
-      re-render the form; `/logout` clears the session so a following
-      request is unauthenticated. `@pytest.mark.skip` until the last unit.
-  - [x] Commit: `Tst: Add skipped gating test for login and session`
-
-#### TDD implementation
-
-*Note: the session config unit originally planned here was split into a
-separate `ft/login-config` PR. That PR delivered `session_secret` and
-`session_https_only` config fields, `_coerce_bool` with strict token
-validation, empty-secret validation in `load_config`, `make_config`
-factory secret default, and all associated test infrastructure. The
-remaining work below assumes `ft/login-config` is merged.*
-
-- [x] Commit: `Ft: Add session config fields and bool coercion`
-- [x] Commit: `Ref: Extract _coerce_bool and DRY out bool coercion tests`
-- [x] Commit: `Ref: DRY out TestLoadConfigEnv boilerplate`
-- [x] Commit: `Ref: DRY out TestLoadConfigToml and TestLoadConfigFlag`
-- [x] Commit: `Ft: Add non-empty session_secret default to make_config`
-
-**Add the itsdangerous dependency**
-
-- [ ] Add `itsdangerous` to `pyproject.toml` dependencies (Starlette
-      `SessionMiddleware` requires it for cookie signing); sync the env.
-- [ ] Commit: `Chr: Add itsdangerous dependency`
-
-**Wire SessionMiddleware and the current-user seam**
-(`tests/web/test_app.py`, `tests/web/test_routes.py`)
-
-- [ ] Red: test asserting `request.session` is populated inside a handler
-      (fails if the middleware is not actually in the stack); an
-      unauthenticated request resolves to no current user (not a default
-      uid, not a 500); a tampered or forged session cookie is rejected as
-      unauthenticated; and a `uid` set in the session round-trips back
-      from `get_current_uid` as an `int` (PR 4 keys auth off the type).
-- [ ] In `app_factory` (`web/app.py`) call `app.add_middleware(
-      SessionMiddleware, secret_key=config.session_secret,
-      https_only=config.session_https_only, same_site="lax")` (the cookie
-      is httponly by default). `add_middleware` wraps the whole app
-      including the routers regardless of call order relative to
-      `include_router`, but place it explicitly in `app_factory` so it is
-      unambiguous. Add `get_current_uid(request) -> int | None` to
-      `web/deps.py` reading `request.session.get("uid")`; this is the only
-      function aware of `request.session` and is the seam `require_auth`
-      consumes in PR 4.
-- [ ] uv run ruff check && uv run pytest
-- [ ] Commit: `Ft: Wire SessionMiddleware and current-user seam`
-
-**Add the login route**
-(`tests/web/test_routes.py`)
-
-- [ ] Red: tests asserting GET `/login` renders the login form page; POST
-      with valid credentials clears any prior session, sets `uid`, and
-      redirects; POST with a wrong password and POST with an unknown email
-      both re-render the form with a generic error and identical surface
-      (no user-enumeration difference); neither logs the password.
-- [ ] Add `web/routes/auth.py` with a `page_login` GET handler rendering a
-      new `templates/auth/login.html` (mirroring the `page_upload` +
-      `upload/page.html` idiom) and a POST handler that calls
-      `get_user_by_email` then `verify_password`; on success
-      `request.session.clear()` then sets `request.session["uid"]` and
-      redirects (302); on failure re-renders the form with an error in the
-      page body (page idiom, not the error builders). Register the auth
-      router in `routes/__init__.py` among the `include_router` calls but
-      before `shortcode_router` (the wildcard `/{code}` must stay last).
-      Add `templates/auth/login.html` extending `base.html`.
-- [ ] uv run ruff check && uv run pytest
-- [ ] Commit: `Ft: Add login route`
-
-**Add the logout route**
-(`tests/web/test_routes.py`)
-
-- [ ] Red: test asserting `/logout` clears the session, a subsequent
-      request is unauthenticated, and logout redirects.
-- [ ] Add a logout handler to `web/routes/auth.py` that calls
-      `request.session.clear()` and redirects (302). Register on the auth
-      router.
-- [ ] uv run ruff check && uv run pytest
-- [ ] Commit: `Ft: Add logout route`
-
-#### Integration and documentation
-
-- [ ] Unskip the `TestLoginSession` gating test; confirm it passes.
-- [ ] Update `doc/module/web.md` (session middleware, `get_current_uid`
-      seam, login/logout routes), `doc/module/templates.md` (auth/login
-      template), and add `/login` and `/logout` to the reserved-namespaces
-      list in `doc/design/routes.md`.
-- [ ] uv run ruff check && uv run pytest
-- [ ] Commit: `Doc: Update web and template docs for ft/login-session`
-
-#### PR
-
-- [ ] gh pr create --title "Ft: Login and session" --body "..."
-
 ### Upload gate (Branch: `ft/upload-gate`)
 
 *Problem: any anonymous visitor can POST to `/upload` and create items
@@ -344,8 +228,43 @@ Ensure all hierarchy works in pure grayscale; color remains semantic only.
 - Swaps should target interior regions only;
   - avoid global reflow by keeping consistent container widths/padding in `base.html`.
 
+#### Login form chrome (deferred from ft/login-session)
+
+- Style the auth/login.html form and error elements (login__form,
+  login__error); both are currently undecorated structural markup
+- Add coverage for the login__form and login__error classes in the
+  template class-consistency / spec test modules
+- Add required and rely on type="email" on the login inputs for
+  client-side validation
+- Inform the user of a bad login via a partial update rather than a
+  full-page re-render. HTMX is the candidate, but verify first whether
+  it can swap an error partial while preserving the 401 status, or
+  whether it only swaps on 2xx by default and needs configuration for
+  error codes. It may not be the right mechanism; find out before
+  committing
+- Based on that finding, plan the idiomatic login error response
+  (status code, swap target, partial template)
+- When this lands, update the affected tests: the BS4 form-structure
+  checks and error-block assertions in test_routes.py assume a
+  full-page render and will change
+
 ### Pre-MVP housecleaning
 
+- Improve `get_templates()` ergonomics: the call-it-everywhere pattern
+  is awkward; build a cleaner shared singleton for the templates
+  instance that call sites can reference directly
+- Default `follow_redirects=False` in the test client fixtures
+  (`t_client`, `t_browser`, `t_htmx`); `TestClient` defaults it to True
+  but route tests rarely want redirects followed, so nearly every
+  redirect assertion has to override it
+- Reconsider whether the error classes belong in the model layer rather
+  than util; they increasingly carry structured domain fields (id,
+  resource, email) rather than being pure utilities
+- Lift the per-instance severity override into DepoError.**init** so all
+  subclasses inherit it the way they inherit the status override, rather
+  than each class reimplementing it
+- Split the single errors module into per-domain modules once it grows
+  large enough that one file hurts maintenance
 - Rename `tests/factories/db.py::insert_user` to `seed_user` to resolve
   naming overlap with `SqliteRepository.insert_user`
 - Split `src/depo/repo/sqlite.py` into per-concern submodules (items,
@@ -358,6 +277,9 @@ Ensure all hierarchy works in pure grayscale; color remains semantic only.
 - Replace empirical maxmem formula (256*n*r*p + 1MiB) in password.py
   with a principled bound once OpenSSL's internal buffer requirement is
   confirmed
+- Add redirect-when-unauthenticated to GET /logout (mirroring the
+  authenticated-redirect already on GET /login), once more of the app
+  exists to redirect to sensibly
 - Plan session secret management UX and dev/prod mode: a `DEPO_MODE`
   config field (`dev`/`prod`), a `gen-secret` CLI command printing a
   suitable random secret to stdout, and adjusted `load_config` behaviour

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ requires-python = ">=3.12"
 dependencies = [
     "click>=8.3.1",
     "fastapi>=0.128.5",
+    "itsdangerous>=2.2.0",
     "jinja2>=3.1.6",
     "pillow>=12.1.0",
     "python-multipart>=0.0.22",

--- a/src/depo/templates/auth/login.html
+++ b/src/depo/templates/auth/login.html
@@ -1,0 +1,16 @@
+{% extends "base.html" %}
+{% block content %}
+<!-- BEGIN: auth/login.html#content -->
+<!-- EXTENDS: base.html -->
+{% if error %}
+<div class="login__error", role="alert">
+  <p>{{ error.message }}</p>
+</div>
+{% endif %}
+<form class="login__form" method="post" action="/login">
+    <input type="email" name="email">
+    <input type="password" name="password">
+    <button type="submit">Log in</button>
+</form>
+<!-- END: auth/login.html#content -->
+{% endblock %}

--- a/src/depo/util/errors.py
+++ b/src/depo/util/errors.py
@@ -349,3 +349,29 @@ class LinkRawNotSupportedError(NotFoundError):
         message = f"Item {code} is a link and has no raw content."
         DepoError.__init__(self, message, context)
         self.code = code
+
+
+# == Auth Domain ==
+class AuthenticationError(DepoError):
+    """Raised when login credentials cannot be verified.
+
+    Carries the attempted email as a named attribute for logging and
+    admin surfaces. The user-facing message is always the generic class
+    default so that a missing account and a wrong password are
+    indistinguishable in the response.
+    """
+
+    severity = Severity.WARNING
+    status = 401
+    message = "Incorrect e-mail or password."
+
+    def __init__(
+        self,
+        email: str,
+        context: dict | None = None,
+        status: int | None = None,
+        severity: Severity | None = None,
+    ):
+        self.email = email
+        self.severity = severity if severity is not None else self.__class__.severity
+        super().__init__(None, context, status)

--- a/src/depo/web/app.py
+++ b/src/depo/web/app.py
@@ -14,6 +14,7 @@ import sqlite3
 from pathlib import Path
 
 from fastapi import FastAPI
+from starlette.middleware.sessions import SessionMiddleware
 from starlette.staticfiles import StaticFiles
 
 from depo.cli.config import DepoConfig
@@ -36,6 +37,14 @@ def app_factory(config: DepoConfig) -> FastAPI:
     # Start FastAPI lifecycle storing DepoConfig
     app = FastAPI()
     app.state.config = config
+
+    # Add middleware here
+    app.add_middleware(
+        SessionMiddleware,
+        secret_key=config.session_secret,
+        https_only=config.session_https_only,
+        same_site="lax",
+    )
 
     # Initialize DB, create Repository, StorageBackend
     app.state.config.db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/src/depo/web/deps.py
+++ b/src/depo/web/deps.py
@@ -30,3 +30,8 @@ def get_storage(request: Request) -> StorageBackend:
 def get_orchestrator(request: Request) -> IngestOrchestrator:
     """Provide the IngestOrchestrator from app state."""
     return request.app.state.orchestrator
+
+
+def get_current_uid(request: Request) -> int | None:
+    """Return the authenticated user's uid from the session, or None."""
+    return request.session.get("uid")

--- a/src/depo/web/routes/__init__.py
+++ b/src/depo/web/routes/__init__.py
@@ -13,6 +13,7 @@ License: Apache-2.0
 from fastapi import APIRouter, Request, Response
 from fastapi.responses import PlainTextResponse, RedirectResponse
 
+from depo.web.routes.auth import auth_router
 from depo.web.routes.shortcode import shortcode_router
 from depo.web.routes.upload import upload, upload_router
 from depo.web.templates import get_templates
@@ -44,4 +45,5 @@ def theme(request: Request) -> Response:
 
 # Merge routers from domain-specific modules
 router.include_router(upload_router)  # Upload routes
+router.include_router(auth_router)  # Auth routes
 router.include_router(shortcode_router)  # Shortcode routes (WILDCARDS MUST BE LAST!)

--- a/src/depo/web/routes/auth.py
+++ b/src/depo/web/routes/auth.py
@@ -1,0 +1,61 @@
+# src/depo/web/routes/auth.py
+"""
+Authentication routes for depo web layer.
+Handles login and logout.
+Author: Marcus Grant
+Created: 2026-06-23
+License: Apache-2.0
+"""
+
+from fastapi import APIRouter, Request, Response
+from fastapi.responses import RedirectResponse
+
+from depo.util.errors import AuthenticationError, NotFoundError
+from depo.util.password import verify_password
+from depo.web.deps import get_current_uid, get_repo
+from depo.web.templates import get_templates
+
+auth_router = APIRouter()
+
+
+def _render_login(request: Request, error: AuthenticationError | None) -> Response:
+    """Render the login page and form with an optional error message."""
+    status = error.status if error else 200
+    return get_templates().TemplateResponse(
+        request=request,
+        name="auth/login.html",
+        status_code=status,
+        context={"error": error},
+    )
+
+
+@auth_router.get("/login")
+async def page_login(request: Request) -> Response:
+    """Serve the login form as a full HTML page."""
+    if get_current_uid(request) is not None:  # Already logged in, redirect home
+        return RedirectResponse(url="/", status_code=302)
+    return _render_login(request, error=None)  # Render login page
+
+
+@auth_router.post("/login")
+async def handle_login(request: Request) -> Response:
+    """Verify credentials and set session cookie on success.
+    Or re-render form on login error."""
+    # Extract login form data and normalize to strings
+    form = await request.form()
+    email, password = form.get("email", ""), form.get("password", "")
+    email = email if isinstance(email, str) else ""
+    password = password if isinstance(password, str) else ""
+    auth_err = AuthenticationError(email)  # Hoisted to simplify control flow
+
+    try:  # Try retrieving user by email given
+        user = get_repo(request).get_user_by_email(email)
+    except NotFoundError:  # If user not found, return login form with error
+        return _render_login(request, error=auth_err)
+    if not verify_password(password, user.pw_hash):  # Verify password hash matches
+        return _render_login(request, error=auth_err)
+
+    # Happy path; credentials match, reset session to user id
+    request.session.clear()  # Clear any existing session data
+    request.session["uid"] = user.id  # Reset user_id in session
+    return RedirectResponse(url="/", status_code=302)

--- a/src/depo/web/routes/auth.py
+++ b/src/depo/web/routes/auth.py
@@ -59,3 +59,10 @@ async def handle_login(request: Request) -> Response:
     request.session.clear()  # Clear any existing session data
     request.session["uid"] = user.id  # Reset user_id in session
     return RedirectResponse(url="/", status_code=302)
+
+
+@auth_router.get("/logout")
+async def handle_logout(request: Request) -> Response:
+    """Clear the session and redirect to root."""
+    request.session.clear()  # Clear session data
+    return RedirectResponse(url="/", status_code=302)  # Redirect to root

--- a/tests/fixtures/__init__.py
+++ b/tests/fixtures/__init__.py
@@ -19,11 +19,18 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from depo.model.item import LinkItem, PicItem, TextItem
+from depo.model.user import User
 from depo.repo.sqlite import SqliteRepository, init_db
 from depo.service.orchestrator import IngestOrchestrator
 from depo.storage.filesystem import FilesystemStorage
+from depo.util.password import hash_password
 from tests.factories import gen_image, make_client, make_ingest_service
-from tests.factories.db import insert_link_item, insert_pic_item, insert_text_item
+from tests.factories.db import (
+    insert_link_item,
+    insert_pic_item,
+    insert_text_item,
+    insert_user,
+)
 
 
 @pytest.fixture
@@ -188,3 +195,25 @@ def t_seeded(tmp_path) -> SeededApp:
     store.put(code=item_txt.code, format=item_txt.format, source_bytes=txt_data)
     store.put(code=item_pic.code, format=item_pic.format, source_bytes=pic_data)
     return SeededApp(client, browser, htmx, item_txt, item_pic, item_link)
+
+
+@dataclass
+class AuthedApp:
+    """TestClient bundled with a seeded user and known plaintext password.
+    Use for login/logout tests where a real user credential is a precondition."""
+
+    client: TestClient
+    user: User
+    password: str
+
+
+@pytest.fixture
+def t_authed(tmp_path) -> AuthedApp:
+    """TestClient with a single user seeded with a real scrypt hash."""
+    client, pw = make_client(tmp_path), "test-password"
+    user = insert_user(
+        conn=cast(FastAPI, client.app).state.repo._conn,
+        email="guy@example.com",
+        pw_hash=hash_password(pw, n=2, r=1, p=1),
+    )
+    return AuthedApp(client=client, user=user, password=pw)

--- a/tests/util/test_errors.py
+++ b/tests/util/test_errors.py
@@ -45,6 +45,7 @@ class TestErrorSeverity:
         errors.UnknownClassificationError: errors.Severity.ERROR,
         errors.ImageDecodeError: errors.Severity.INFO,
         errors.UnsupportedFormatError: errors.Severity.INFO,
+        errors.AuthenticationError: errors.Severity.WARNING,
     }
 
     def test_each_subclass_resolves_expected_severity(self):
@@ -427,3 +428,33 @@ class TestLinkRawNotSupportedError:
         err = self.err(code="abc123")
         assert err.code == "abc123"
         assert "abc123" in str(err)
+
+
+# == Auth Domain ==
+
+_EMAIL = "guy@test.se"
+
+
+class TestAuthenticationError:
+    """Tests for AuthenticationError (401)."""
+
+    def test_defaults(self):
+        """Class-level defaults: inherits DepoError, status 401, severity WARNING."""
+        assert issubclass(errors.AuthenticationError, errors.DepoError)
+        assert errors.AuthenticationError.status == 401
+        assert errors.AuthenticationError.severity == errors.Severity.WARNING
+        msg = str(errors.AuthenticationError(_EMAIL))
+        assert ("mail" in msg) == ("pass" in msg)  # both or neither credential is named
+
+    def test_stores_email_generic_message(self):
+        """Constructor stores email as a named attribute; message stays generic."""
+        e = errors.AuthenticationError(_EMAIL)
+        assert e.email == _EMAIL
+        assert e.message == errors.AuthenticationError.message
+        assert _EMAIL not in e.message  # email should not be in the message
+
+    def test_severity_overridable_per_instance(self):
+        """An instance severity override takes effect, class default unchanged."""
+        e = errors.AuthenticationError(_EMAIL, severity=errors.Severity.INFO)
+        assert e.severity == errors.Severity.INFO
+        assert e.__class__.severity == errors.Severity.WARNING

--- a/tests/web/test_app.py
+++ b/tests/web/test_app.py
@@ -4,13 +4,15 @@ Tests for the FastAPI app factory and health check.
 
 Author: Marcus Grant
 Created: 2026-02-09
+Revised: [2026-06-23]
 License: Apache-2.0
 """
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
 from depo.web.app import app_factory
+from depo.web.deps import get_current_uid
 from tests.factories import make_config
 
 
@@ -58,3 +60,57 @@ class TestConfigWiring:
         client = TestClient(app_factory(make_config(tmp_path, min_code_len=12)))
         resp = client.post("/upload", files={"file": ("t.txt", b"hello world")})
         assert len(resp.headers["X-Depo-Code"]) == 12
+
+
+class TestSessionMiddleware:
+    """Tests that SessionMiddleware is wired and the current-user seam works."""
+
+    def _probe_request(self, path, probe_fn, **kwargs):
+        """Fire a GET /_probe/response against a full-stack app and return the response.
+        probe_fn receives the Request; its return value is serialized as JSON.
+        Extra kwargs are forwarded to the TestClient.get call, allowing callers
+        to pass cookies, headers, or other request parameters.
+        Use to test middleware and seam behavior against the real app stack
+        without hitting production routes.
+        """
+        app = app_factory(make_config(path))
+        app.add_api_route("/_probe/response", probe_fn, methods=["GET"])
+        client = TestClient(app)
+        if "cookies" in kwargs:
+            client.cookies.update(kwargs.pop("cookies"))
+        return client.get("/_probe/response", **kwargs)
+
+    def _uid_probe(self, request: Request):
+        return {"uid": get_current_uid(request)}  # should not raise
+
+    def test_session_available_in_handler(self, tmp_path):
+        """A handler can read and write request.session without error."""
+
+        def _session_probe(request: Request):
+            request.session["probe"] = "ok"
+            return {"probe": request.session["probe"]}
+
+        resp = self._probe_request(tmp_path, _session_probe)
+        assert resp.status_code == 200
+        assert resp.json()["probe"] == "ok"
+
+    def test_unauthenticated_request_has_no_uid(self, tmp_path):
+        """get_current_uid returns None for a request with no session uid."""
+        assert self._probe_request(tmp_path, self._uid_probe).json()["uid"] is None
+
+    def test_tampered_cookie_rejected(self, tmp_path):
+        """A forged or tampered session cookie resolves to no current user."""
+        bad_cookie = {"session": "bad_cookie"}
+        resp = self._probe_request(tmp_path, self._uid_probe, cookies=bad_cookie)
+        assert resp.json()["uid"] is None
+
+    def test_uid_round_trips_as_int(self, tmp_path):
+        """A uid written to the session is returned by get_current_uid as int."""
+
+        def _set_and_read_probe(request: Request):
+            request.session["uid"] = 42
+            return {"uid": get_current_uid(request)}
+
+        resp = self._probe_request(tmp_path, _set_and_read_probe)
+        assert resp.json()["uid"] == 42
+        assert isinstance(resp.json()["uid"], int)

--- a/tests/web/test_routes.py
+++ b/tests/web/test_routes.py
@@ -8,10 +8,14 @@ Created: 2026-02-23
 License: Apache-2.0
 """
 
-import pytest
+from typing import cast
+
 from bs4 import BeautifulSoup as BSoup
+from fastapi import FastAPI
 
 from depo.util.errors import AuthenticationError
+from depo.util.password import hash_password
+from tests.factories.db import insert_user
 
 
 class TestRouteRegistration:
@@ -129,42 +133,49 @@ class TestLogoutRoute:
         resp = t_authed.client.get("/logout", follow_redirects=False)
         assert resp.status_code == 302
         assert "session" not in resp.cookies
-        resp = t_authed.client.get("/", follow_redirects=False)
-        assert "session" not in resp.cookies
+        assert "session" not in t_authed.client.get("/", follow_redirects=False).cookies
 
 
-@pytest.mark.skip(reason="enabled at end of ft/login-session")
 class TestLoginSession:
     """End-to-end login, session, and logout over HTTP.
 
     Probes the session lifecycle via the t_client cookie jar; no
     authenticated-only route exists until ft/upload-gate, so value-level
-    uid recognition is left to the get_current_uid seam unit test.
+    uid recognition is left to the get_current_uid unit test.
     """
+
+    def _seed_user(self, t_client):
+        """Seed a test user with a known password into the client's db.
+        Returns (mail, pw) for use in login form data."""
+        conn = cast(FastAPI, t_client.app).state.repo._conn
+        mail, pw = "guy@example.com", "test-password"
+        insert_user(conn, email=mail, pw_hash=hash_password(pw, n=2, r=1, p=1))
+        return mail, pw
 
     def test_valid_login_starts_session(self, t_client):
         """POST /login with valid creds 302s and sets a session cookie."""
-        # should seed a user with a known password
-        # should POST email + password to /login with follow_redirects=False
-        # should get 302
-        # should find the session cookie present in the client jar
-        _ = t_client
-        ...
+        mail, pw = self._seed_user(t_client)
+        data = {"email": mail, "password": pw}
+        resp = t_client.post("/login", data=data, follow_redirects=False)
+        assert resp.status_code == 302
+        assert "session" in resp.cookies
 
     def test_bad_credentials_rejected(self, t_client):
         """POST /login with a wrong password re-renders the form, no session."""
-        # should seed a user with a known password
-        # should POST email + wrong password to /login
-        # should re-render the login form (200, html, error surfaced in body)
-        # should set no session cookie
-        _ = t_client
-        ...
+        mail, _ = self._seed_user(t_client)
+        data = {"email": mail, "password": "bad-password"}
+        resp = t_client.post("/login", data=data, follow_redirects=False)
+        assert resp.status_code == 401
+        assert "session" not in resp.cookies
+        assert AuthenticationError.message in resp.text
 
     def test_logout_clears_session(self, t_client):
         """GET /logout 302s and clears the session cookie."""
-        # should seed a user and log in
-        # should GET /logout with follow_redirects=False
-        # should get 302
-        # should find the session cookie cleared in the client jar
-        _ = t_client
-        ...
+        conn, pw = cast(FastAPI, t_client.app).state.repo._conn, "test-password"
+        pw_hash, mail = hash_password(pw, n=2, r=1, p=1), "guy@example.com"
+        insert_user(conn, email=mail, pw_hash=pw_hash)
+        data = {"email": mail, "password": pw}
+        t_client.post("/login", data=data, follow_redirects=False)
+        resp = t_client.get("/logout", follow_redirects=False)
+        assert resp.status_code == 302
+        assert "session" not in resp.cookies

--- a/tests/web/test_routes.py
+++ b/tests/web/test_routes.py
@@ -9,6 +9,9 @@ License: Apache-2.0
 """
 
 import pytest
+from bs4 import BeautifulSoup as BSoup
+
+from depo.util.errors import AuthenticationError
 
 
 class TestRouteRegistration:
@@ -57,6 +60,63 @@ class TestRootRedirect:
         resp = t_client.get(url="/", follow_redirects=False)
         assert resp.status_code == 302
         assert resp.headers.get("location") == "/upload"
+
+
+class TestLoginRoute:
+    """Tests for GET and POST /login."""
+
+    def _assert_login_form(self, resp):
+        """Assert the response is an HTML page containing a valid login form."""
+        assert "text/html" in resp.headers["content-type"]
+        form = BSoup(resp.text, "html.parser").select_one("form.login__form")
+        assert form is not None
+        assert str(form.get("method", "")).lower() == "post"
+        assert form.select_one("input[type='email']") is not None
+        assert form.select_one("input[type='password']") is not None
+        assert form.select_one("button[type='submit']") is not None
+
+    def _assert_login_rejected(self, resp):
+        """Assert the response is a rejected login: form re-rendered with a
+        generic error, 401 status, and no session established."""
+        self._assert_login_form(resp)
+        assert resp.status_code == 401
+        assert AuthenticationError.message in resp.text
+        assert '"login__error"' in resp.text
+        assert "session" not in resp.cookies
+
+    def test_get_login_renders_form(self, t_browser):
+        """GET /login returns 200 with the login form."""
+        resp = t_browser.get("/login")
+        self._assert_login_form(resp)
+        assert resp.status_code == 200
+        assert "session" not in resp.cookies
+
+    def test_get_login_authenticated_redirects(self, t_authed):
+        """GET /login while authenticated redirects to / instead of rendering."""
+        data = {"email": t_authed.user.email, "password": t_authed.password}
+        t_authed.client.post("/login", data=data, follow_redirects=False)
+        resp = t_authed.client.get("/login", follow_redirects=False)
+        assert resp.status_code == 302
+        assert resp.headers.get("location") == "/"
+
+    def test_post_valid_credentials_redirects(self, t_authed):
+        """POST /login with valid credentials 302s and sets session uid."""
+        data = {"email": t_authed.user.email, "password": t_authed.password}
+        resp = t_authed.client.post("/login", data=data, follow_redirects=False)
+        assert resp.status_code == 302
+        assert "session" in resp.cookies
+
+    def test_post_wrong_password_rerenders_form(self, t_authed):
+        """POST /login with wrong password re-renders the form with an error."""
+        data = {"email": t_authed.user.email, "password": "wrong-pass"}
+        resp = t_authed.client.post("/login", data=data, follow_redirects=False)
+        self._assert_login_rejected(resp)
+
+    def test_post_unknown_email_rerenders_form(self, t_authed):
+        """POST /login with unknown email re-renders the form with an error."""
+        data = {"email": "not-an@email.com", "password": t_authed.password}
+        resp = t_authed.client.post("/login", data=data, follow_redirects=False)
+        self._assert_login_rejected(resp)
 
 
 @pytest.mark.skip(reason="enabled at end of ft/login-session")

--- a/tests/web/test_routes.py
+++ b/tests/web/test_routes.py
@@ -119,6 +119,20 @@ class TestLoginRoute:
         self._assert_login_rejected(resp)
 
 
+class TestLogoutRoute:
+    """Tests for GET /logout."""
+
+    def test_logout_clears_session_and_redirects(self, t_authed):
+        """GET /logout clears the session, subsequent request is unauthenticated."""
+        data = {"email": t_authed.user.email, "password": t_authed.password}
+        t_authed.client.post("/login", data=data, follow_redirects=False)
+        resp = t_authed.client.get("/logout", follow_redirects=False)
+        assert resp.status_code == 302
+        assert "session" not in resp.cookies
+        resp = t_authed.client.get("/", follow_redirects=False)
+        assert "session" not in resp.cookies
+
+
 @pytest.mark.skip(reason="enabled at end of ft/login-session")
 class TestLoginSession:
     """End-to-end login, session, and logout over HTTP.

--- a/uv.lock
+++ b/uv.lock
@@ -115,6 +115,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "click" },
     { name = "fastapi" },
+    { name = "itsdangerous" },
     { name = "jinja2" },
     { name = "pillow" },
     { name = "python-multipart" },
@@ -139,6 +140,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "fastapi", specifier = ">=0.128.5" },
+    { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "pillow", specifier = ">=12.1.0" },
     { name = "python-multipart", specifier = ">=0.0.22" },
@@ -266,6 +268,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "itsdangerous"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9c/cb/8ac0172223afbccb63986cc25049b154ecfb5e85932587206f42317be31d/itsdangerous-2.2.0.tar.gz", hash = "sha256:e0050c0b7da1eea53ffaf149c0cfbb5c6e2e2b69c4bef22c81fa6eb73e5f6173", size = 54410, upload-time = "2024-04-16T21:28:15.614Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/96/92447566d16df59b2a776c0fb82dbc4d9e07cd95062562af01e408583fc4/itsdangerous-2.2.0-py3-none-any.whl", hash = "sha256:c6242fc49e35958c8b15141343aa660db5fc54d4f13a1db01a3f5891b98700ef", size = 16234, upload-time = "2024-04-16T21:28:14.499Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Wires authenticated sessions end to end: signed-cookie session
middleware, a login route that verifies credentials and starts a
session, a logout route that ends it, and a function that reads the
current user id from a request. Branches from the merged
ft/login-config, which supplied session_secret, session_https_only,
and the non-empty-secret validation.

## What landed

- itsdangerous dependency for cookie signing
- SessionMiddleware in app_factory (secret_key, https_only,
  same_site=lax); get_current_uid(request) -> int | None in
  web/deps.py, the only web-layer function that touches
  request.session directly
- AuthenticationError (401, WARNING): carries the attempted email as a
  named attribute for logging and admin surfaces, never in the
  user-facing message; generic message so unknown-email and
  wrong-password are indistinguishable; per-instance severity override
- web/routes/auth.py: GET /login renders the form and redirects to /
  when already authenticated; POST /login verifies credentials, starts
  a session on success, re-renders with a generic 401 error on failure;
  GET /logout clears the session and redirects. Both failure paths
  converge to one surface. auth_router registered before the shortcode
  wildcard
- auth/login.html with login__form and login__error hooks, undecorated
  pending the chrome PR
- TestLoginSession integration gate unskipped and passing

## Out of scope

- The /upload gate and require_auth as a route dependency
  (ft/upload-gate, which consumes get_current_uid)
- HTMX login error feedback, form styling, and class-consistency
  coverage (deferred to Global Chrome; recorded in mvp.md)
- CSRF, server-side session store, email login and password reset
  (tracked separately)

## Testing

uv run ruff check && uv run pyright && uv run pytest: 717 passed.
